### PR TITLE
Drop id wrapper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ### Added
 - Drop the cached `ikey`/`ihash` fields from identifiers (@jonludlam, #1479)
 - Remove the `'a Identifier.id` record wrapper (@jonludlam, #1479)
+- Hash-cons resolved module paths, so repeated paths are shared again in
+  `.odoc`/`.odocl` files (@jonludlam, #1479)
 - Support for OxCaml unboxed named types (@art-w, #1407)
 - Support for OxCaml zero alloc definitions (@Leonidas-from-XIV, #1422, #1444)
 - Support for OxCaml modalities (@art-w, #1420)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 # Unreleased
 
 ### Added
-- Drop the cached `ikey`/`ihash` fields from identifiers (@jonludlam)
-- Remove the `'a Identifier.id` record wrapper (@jonludlam)
+- Drop the cached `ikey`/`ihash` fields from identifiers (@jonludlam, #1479)
+- Remove the `'a Identifier.id` record wrapper (@jonludlam, #1479)
 - Support for OxCaml unboxed named types (@art-w, #1407)
 - Support for OxCaml zero alloc definitions (@Leonidas-from-XIV, #1422, #1444)
 - Support for OxCaml modalities (@art-w, #1420)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Drop the cached `ikey`/`ihash` fields from identifiers (@jonludlam)
+- Remove the `'a Identifier.id` record wrapper (@jonludlam)
 - Support for OxCaml unboxed named types (@art-w, #1407)
 - Support for OxCaml zero alloc definitions (@Leonidas-from-XIV, #1422, #1444)
 - Support for OxCaml modalities (@art-w, #1420)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ### Added
+- Drop the cached `ikey`/`ihash` fields from identifiers (@jonludlam)
 - Support for OxCaml unboxed named types (@art-w, #1407)
 - Support for OxCaml zero alloc definitions (@Leonidas-from-XIV, #1422, #1444)
 - Support for OxCaml modalities (@art-w, #1420)

--- a/sherlodoc/index/load_doc.ml
+++ b/sherlodoc/index/load_doc.ml
@@ -144,21 +144,21 @@ let register_kind ~db elt =
 
 let rec categorize id =
   let open Odoc_model.Paths in
-  match id.Identifier.iv with
+  match id with
   | `Root _ | `Page _ | `LeafPage _ -> `definition
   | `ModuleType _ -> `declaration
   | `Parameter _ -> `ignore (* redundant with indexed signature *)
   | ( `InstanceVariable _ | `Method _ | `Field _ | `Result _ | `Label _ | `Type _
     | `Exception _ | `Class _ | `ClassType _ | `Value _ | `Constructor _ | `Extension _
     | `ExtensionDecl _ | `Module _ | `UnboxedField _ ) as x ->
-      let parent = Identifier.label_parent { Identifier.iv = x } in
+      let parent = Identifier.label_parent x in
       categorize (parent :> Identifier.Any.t)
   | `AssetFile _ | `SourceLocationMod _ | `SourceLocation _ | `SourcePage _
   | `SourceLocationInternal _ ->
       `ignore (* unclear what to do with those *)
 
 let categorize Odoc_index.Entry.{ id; _ } =
-  match id.iv with
+  match id with
   | `ModuleType (parent, _) ->
       (* A module type itself is not *from* a module type, but it might be if one
        of its parents is a module type. *)

--- a/sherlodoc/index/load_doc.ml
+++ b/sherlodoc/index/load_doc.ml
@@ -151,7 +151,7 @@ let rec categorize id =
   | ( `InstanceVariable _ | `Method _ | `Field _ | `Result _ | `Label _ | `Type _
     | `Exception _ | `Class _ | `ClassType _ | `Value _ | `Constructor _ | `Extension _
     | `ExtensionDecl _ | `Module _ | `UnboxedField _ ) as x ->
-      let parent = Identifier.label_parent { id with iv = x } in
+      let parent = Identifier.label_parent { Identifier.iv = x } in
       categorize (parent :> Identifier.Any.t)
   | `AssetFile _ | `SourceLocationMod _ | `SourceLocation _ | `SourcePage _
   | `SourceLocationInternal _ ->

--- a/sherlodoc/index/typename.ml
+++ b/sherlodoc/index/typename.ml
@@ -3,13 +3,13 @@ module Identifier = Odoc_model.Paths.Identifier
 module TypeName = Odoc_model.Names.TypeName
 module ModuleName = Odoc_model.Names.ModuleName
 
-let rec show_ident_long h (r : Identifier.t_pv Identifier.id) =
-  match r.iv with
+let rec show_ident_long h (r : Identifier.t) =
+  match r with
   | `Type (md, n) -> Format.fprintf h "%a.%s" show_signature md (TypeName.to_string n)
   | _ -> Format.fprintf h "%S" (r |> Identifier.fullname |> String.concat ".")
 
 and show_signature h sig_ =
-  match sig_.iv with
+  match sig_ with
   | `Root (_, name) -> Format.fprintf h "%s" (ModuleName.to_string name)
   | `Module (pt, mdl) ->
       Format.fprintf h "%a.%s" show_signature pt (ModuleName.to_string mdl)

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -401,8 +401,7 @@ let heading_level_to_int = function
   | `Paragraph -> 4
   | `Subparagraph -> 5
 
-let heading
-    (attrs, `Label (_, label), text) =
+let heading (attrs, `Label (_, label), text) =
   let label = Odoc_model.Names.LabelName.to_string label in
   let title = inline_element_list text in
   let level = heading_level_to_int attrs.Comment.heading_level in

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -402,7 +402,7 @@ let heading_level_to_int = function
   | `Subparagraph -> 5
 
 let heading
-    (attrs, { Odoc_model.Paths.Identifier.iv = `Label (_, label); _ }, text) =
+    (attrs, `Label (_, label), text) =
   let label = Odoc_model.Names.LabelName.to_string label in
   let title = inline_element_list text in
   let level = heading_level_to_int attrs.Comment.heading_level in

--- a/src/document/generator.ml
+++ b/src/document/generator.ml
@@ -280,7 +280,7 @@ module Make (Syntax : SYNTAX) = struct
     let info_of_info : Lang.Source_info.annotation -> Source_page.info option =
       function
       | Definition id -> (
-          match id.iv with
+          match id with
           | `SourceLocation (_, def) -> Some (Anchor (DefName.to_string def))
           | `SourceLocationInternal (_, local) ->
               Some (Anchor (LocalName.to_string local))
@@ -549,7 +549,7 @@ module Make (Syntax : SYNTAX) = struct
             match lbl with None -> O.noop | Some lbl -> label lbl ++ O.txt ":"
           in
           let name =
-            match m_arg.id.iv with
+            match m_arg.id with
             | `Parameter (_, name) -> ModuleName.to_string name
           in
           let dst = type_expr dst in
@@ -1387,37 +1387,37 @@ module Make (Syntax : SYNTAX) = struct
   end = struct
     let internal_module m =
       let open Lang.Module in
-      match m.id.iv with
+      match m.id with
       | `Module (_, name) when ModuleName.is_hidden name -> true
       | _ -> false
 
     let internal_type t =
       let open Lang.TypeDecl in
-      match t.id.iv with
+      match t.id with
       | `Type (_, name) when TypeName.is_hidden name -> true
       | _ -> false
 
     let internal_value v =
       let open Lang.Value in
-      match v.id.iv with
+      match v.id with
       | `Value (_, name) when ValueName.is_hidden name -> true
       | _ -> false
 
     let internal_module_type t =
       let open Lang.ModuleType in
-      match t.id.iv with
+      match t.id with
       | `ModuleType (_, name) when ModuleTypeName.is_hidden name -> true
       | _ -> false
 
     let internal_module_substitution t =
       let open Lang.ModuleSubstitution in
-      match t.id.iv with
+      match t.id with
       | `Module (_, name) when ModuleName.is_hidden name -> true
       | _ -> false
 
     let internal_module_type_substitution t =
       let open Lang.ModuleTypeSubstitution in
-      match t.id.iv with
+      match t.id with
       | `ModuleType (_, name) when ModuleTypeName.is_hidden name -> true
       | _ -> false
 
@@ -1995,7 +1995,7 @@ module Make (Syntax : SYNTAX) = struct
 
     let page (t : Odoc_model.Lang.Page.t) =
       (*let name =
-          match t.name.iv with `Page (_, name) | `LeafPage (_, name) -> name
+          match t.name with `Page (_, name) | `LeafPage (_, name) -> name
         in*)
       (*let title = Odoc_model.Names.PageName.to_string name in*)
       let url = Url.Path.from_identifier t.name in

--- a/src/document/sidebar.ml
+++ b/src/document/sidebar.ml
@@ -98,7 +98,7 @@ end = struct
                   | Some t -> t
                   | None ->
                       let name =
-                        match entry.id.iv with
+                        match entry.id with
                         | `LeafPage (Some parent, name)
                           when Astring.String.equal
                                  (Names.PageName.to_string name)

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -70,12 +70,9 @@ let render_path : Path.t -> string =
 
 module Path = struct
   type nonsrc =
-    [ Identifier.Page.t
-    | Identifier.Signature.t
-    | Identifier.ClassSignature.t ]
+    [ Identifier.Page.t | Identifier.Signature.t | Identifier.ClassSignature.t ]
 
-  type any =
-    [ nonsrc | Identifier.SourcePage.t | Identifier.AssetFile.t ]
+  type any = [ nonsrc | Identifier.SourcePage.t | Identifier.AssetFile.t ]
 
   type kind =
     [ `Module
@@ -290,7 +287,8 @@ module Anchor = struct
         let page = Path.from_identifier (p :> Path.any) in
         { page; kind = `LeafPage; anchor = "" }
     (* For all these identifiers, page names and anchors are the same *)
-    | `Parameter _ | `Result _ | `ModuleType _ | `Class _ | `ClassType _ as p ->
+    | (`Parameter _ | `Result _ | `ModuleType _ | `Class _ | `ClassType _) as p
+      ->
         anchorify_path @@ Path.from_identifier p
     | `Type (parent, type_name) ->
         let page = Path.from_identifier (parent :> Path.any) in
@@ -365,8 +363,7 @@ module Anchor = struct
            grand-parent. *)
         match parent with
         | `Type (gp, _) -> mk ~kind:`Section gp str_name
-        | #Path.nonsrc as p ->
-            mk ~kind:`Section (p :> Path.any) str_name)
+        | #Path.nonsrc as p -> mk ~kind:`Section (p :> Path.any) str_name)
     | `SourceLocation (parent, loc) ->
         let page = Path.from_identifier (parent :> Path.any) in
         { page; kind = `SourceAnchor; anchor = DefName.to_string loc }
@@ -424,8 +421,7 @@ let from_path page =
 
 let from_identifier ~stop_before x =
   match x with
-  | #Path.any as p when not stop_before ->
-      from_path @@ Path.from_identifier p
+  | #Path.any as p when not stop_before -> from_path @@ Path.from_identifier p
   | p -> Anchor.from_identifier p
 
 let from_asset_identifier p = from_path @@ Path.from_identifier p

--- a/src/document/url.ml
+++ b/src/document/url.ml
@@ -69,15 +69,13 @@ let render_path : Path.t -> string =
   render_path
 
 module Path = struct
-  type nonsrc_pv =
-    [ Identifier.Page.t_pv
-    | Identifier.Signature.t_pv
-    | Identifier.ClassSignature.t_pv ]
+  type nonsrc =
+    [ Identifier.Page.t
+    | Identifier.Signature.t
+    | Identifier.ClassSignature.t ]
 
-  type any_pv =
-    [ nonsrc_pv | Identifier.SourcePage.t_pv | Identifier.AssetFile.t_pv ]
-
-  and any = any_pv Identifier.id
+  type any =
+    [ nonsrc | Identifier.SourcePage.t | Identifier.AssetFile.t ]
 
   type kind =
     [ `Module
@@ -114,7 +112,7 @@ module Path = struct
   let rec from_identifier : any -> t =
    fun x ->
     match x with
-    | { iv = `Root (parent, unit_name); _ } ->
+    | `Root (parent, unit_name) ->
         let parent =
           match parent with
           | Some p -> Some (from_identifier (p :> any))
@@ -123,7 +121,7 @@ module Path = struct
         let kind = `Module in
         let name = ModuleName.to_string unit_name in
         mk ?parent kind name
-    | { iv = `Page (parent, page_name); _ } ->
+    | `Page (parent, page_name) ->
         let parent =
           match parent with
           | Some p -> Some (from_identifier (p :> any))
@@ -132,7 +130,7 @@ module Path = struct
         let kind = `Page in
         let name = PageName.to_string page_name in
         mk ?parent kind name
-    | { iv = `LeafPage (parent, page_name); _ } ->
+    | `LeafPage (parent, page_name) ->
         let parent =
           match parent with
           | Some p -> Some (from_identifier (p :> any))
@@ -141,44 +139,44 @@ module Path = struct
         let kind = `LeafPage in
         let name = PageName.to_string page_name in
         mk ?parent kind name
-    | { iv = `Module (parent, mod_name); _ } ->
+    | `Module (parent, mod_name) ->
         let parent = from_identifier (parent :> any) in
         let kind = `Module in
         let name = ModuleName.to_string mod_name in
         mk ~parent kind name
-    | { iv = `Parameter (functor_id, arg_name); _ } as p ->
+    | `Parameter (functor_id, arg_name) as p ->
         let parent = from_identifier (functor_id :> any) in
         let arg_num = Identifier.FunctorParameter.functor_arg_pos p in
         let kind = `Parameter arg_num in
         let name = ModuleName.to_string arg_name in
         mk ~parent kind name
-    | { iv = `ModuleType (parent, modt_name); _ } ->
+    | `ModuleType (parent, modt_name) ->
         let parent = from_identifier (parent :> any) in
         let kind = `ModuleType in
         let name = ModuleTypeName.to_string modt_name in
         mk ~parent kind name
-    | { iv = `Class (parent, name); _ } ->
+    | `Class (parent, name) ->
         let parent = from_identifier (parent :> any) in
         let kind = `Class in
         let name = TypeName.to_string name in
         mk ~parent kind name
-    | { iv = `ClassType (parent, name); _ } ->
+    | `ClassType (parent, name) ->
         let parent = from_identifier (parent :> any) in
         let kind = `ClassType in
         let name = TypeName.to_string name in
         mk ~parent kind name
-    | { iv = `Result p; _ } -> from_identifier (p :> any)
-    | { iv = `SourcePage (parent, name); _ } ->
+    | `Result p -> from_identifier (p :> any)
+    | `SourcePage (parent, name) ->
         let parent = from_identifier (parent :> any) in
         let kind = `SourcePage in
         mk ~parent kind name
-    | { iv = `AssetFile (parent, name); _ } ->
+    | `AssetFile (parent, name) ->
         let parent = from_identifier (parent :> any) in
         let kind = `File in
         let name = AssetName.to_string name in
         mk ~parent kind name
 
-  let from_identifier p = from_identifier (p : [< any_pv ] Identifier.id :> any)
+  let from_identifier p = from_identifier (p : [< any ] :> any)
 
   let to_list url =
     let rec loop acc { parent; name; kind } =
@@ -274,7 +272,7 @@ module Anchor = struct
   let suffix_for_constructor x = x
 
   let rec from_identifier : Identifier.t -> t = function
-    | { iv = `Module (parent, mod_name); _ } ->
+    | `Module (parent, mod_name) ->
         let parent = Path.from_identifier (parent :> Path.any) in
         let kind = `Module in
         let anchor =
@@ -282,27 +280,24 @@ module Anchor = struct
             (ModuleName.to_string mod_name)
         in
         { page = parent; anchor; kind }
-    | { iv = `Root _; _ } as p ->
+    | `Root _ as p ->
         let page = Path.from_identifier (p :> Path.any) in
         { page; kind = `Module; anchor = "" }
-    | { iv = `Page _; _ } as p ->
+    | `Page _ as p ->
         let page = Path.from_identifier (p :> Path.any) in
         { page; kind = `Page; anchor = "" }
-    | { iv = `LeafPage _; _ } as p ->
+    | `LeafPage _ as p ->
         let page = Path.from_identifier (p :> Path.any) in
         { page; kind = `LeafPage; anchor = "" }
     (* For all these identifiers, page names and anchors are the same *)
-    | {
-        iv = `Parameter _ | `Result _ | `ModuleType _ | `Class _ | `ClassType _;
-        _;
-      } as p ->
+    | `Parameter _ | `Result _ | `ModuleType _ | `Class _ | `ClassType _ as p ->
         anchorify_path @@ Path.from_identifier p
-    | { iv = `Type (parent, type_name); _ } ->
+    | `Type (parent, type_name) ->
         let page = Path.from_identifier (parent :> Path.any) in
         let kind = `Type in
         let name = TypeName.to_string type_name in
         { page; anchor = Format.asprintf "%a-%s" pp_kind kind name; kind }
-    | { iv = `Extension (parent, name); _ } ->
+    | `Extension (parent, name) ->
         let page = Path.from_identifier (parent :> Path.any) in
         let kind = `Extension in
         {
@@ -311,7 +306,7 @@ module Anchor = struct
             Format.asprintf "%a-%s" pp_kind kind (ExtensionName.to_string name);
           kind;
         }
-    | { iv = `ExtensionDecl (parent, name, _); _ } ->
+    | `ExtensionDecl (parent, name, _) ->
         let page = Path.from_identifier (parent :> Path.any) in
         let kind = `ExtensionDecl in
         {
@@ -320,7 +315,7 @@ module Anchor = struct
             Format.asprintf "%a-%s" pp_kind kind (ExtensionName.to_string name);
           kind;
         }
-    | { iv = `Exception (parent, name); _ } ->
+    | `Exception (parent, name) ->
         let page = Path.from_identifier (parent :> Path.any) in
         let kind = `Exception in
         {
@@ -329,7 +324,7 @@ module Anchor = struct
             Format.asprintf "%a-%s" pp_kind kind (ExceptionName.to_string name);
           kind;
         }
-    | { iv = `Value (parent, name); _ } ->
+    | `Value (parent, name) ->
         let page = Path.from_identifier (parent :> Path.any) in
         let kind = `Val in
         {
@@ -338,53 +333,53 @@ module Anchor = struct
             Format.asprintf "%a-%s" pp_kind kind (ValueName.to_string name);
           kind;
         }
-    | { iv = `Method (parent, name); _ } ->
+    | `Method (parent, name) ->
         let str_name = MethodName.to_string name in
         let page = Path.from_identifier (parent :> Path.any) in
         let kind = `Method in
         { page; anchor = Format.asprintf "%a-%s" pp_kind kind str_name; kind }
-    | { iv = `InstanceVariable (parent, name); _ } ->
+    | `InstanceVariable (parent, name) ->
         let str_name = InstanceVariableName.to_string name in
         let page = Path.from_identifier (parent :> Path.any) in
         let kind = `Val in
         { page; anchor = Format.asprintf "%a-%s" pp_kind kind str_name; kind }
-    | { iv = `Constructor (parent, name); _ } ->
+    | `Constructor (parent, name) ->
         let page = from_identifier (parent :> Identifier.t) in
         let kind = `Constructor in
         let suffix = suffix_for_constructor (ConstructorName.to_string name) in
         add_suffix ~kind page suffix
-    | { iv = `Field (parent, name); _ } ->
+    | `Field (parent, name) ->
         let page = from_identifier (parent :> Identifier.t) in
         let kind = `Field in
         let suffix = FieldName.to_string name in
         add_suffix ~kind page suffix
-    | { iv = `UnboxedField (parent, name); _ } ->
+    | `UnboxedField (parent, name) ->
         let page = from_identifier (parent :> Identifier.t) in
         let kind = `UnboxedField in
         let suffix = UnboxedFieldName.to_string name in
         add_suffix ~kind page suffix
-    | { iv = `Label (parent, anchor); _ } -> (
+    | `Label (parent, anchor) -> (
         let str_name = LabelName.to_string anchor in
         (* [Identifier.LabelParent.t] contains datatypes. [`CoreType] can't
            happen, [`Type] may not happen either but just in case, use the
            grand-parent. *)
         match parent with
-        | { iv = `Type (gp, _); _ } -> mk ~kind:`Section gp str_name
-        | { iv = #Path.nonsrc_pv; _ } as p ->
+        | `Type (gp, _) -> mk ~kind:`Section gp str_name
+        | #Path.nonsrc as p ->
             mk ~kind:`Section (p :> Path.any) str_name)
-    | { iv = `SourceLocation (parent, loc); _ } ->
+    | `SourceLocation (parent, loc) ->
         let page = Path.from_identifier (parent :> Path.any) in
         { page; kind = `SourceAnchor; anchor = DefName.to_string loc }
-    | { iv = `SourceLocationInternal (parent, loc); _ } ->
+    | `SourceLocationInternal (parent, loc) ->
         let page = Path.from_identifier (parent :> Path.any) in
         { page; kind = `SourceAnchor; anchor = LocalName.to_string loc }
-    | { iv = `SourceLocationMod parent; _ } ->
+    | `SourceLocationMod parent ->
         let page = Path.from_identifier (parent :> Path.any) in
         { page; kind = `SourceAnchor; anchor = "" }
-    | { iv = `SourcePage _; _ } as p ->
+    | `SourcePage _ as p ->
         let page = Path.from_identifier (p :> Path.any) in
         { page; kind = `Page; anchor = "" }
-    | { iv = `AssetFile _; _ } as p ->
+    | `AssetFile _ as p ->
         let page = Path.from_identifier p in
         { page; kind = `File; anchor = "" }
 
@@ -429,7 +424,7 @@ let from_path page =
 
 let from_identifier ~stop_before x =
   match x with
-  | { Identifier.iv = #Path.any_pv; _ } as p when not stop_before ->
+  | #Path.any as p when not stop_before ->
       from_path @@ Path.from_identifier p
   | p -> Anchor.from_identifier p
 

--- a/src/document/url.mli
+++ b/src/document/url.mli
@@ -22,16 +22,14 @@ module Path : sig
 
   type t = { kind : kind; parent : t option; name : string }
 
-  type any_pv =
-    [ Identifier.Page.t_pv
-    | Identifier.Signature.t_pv
-    | Identifier.ClassSignature.t_pv
-    | Identifier.SourcePage.t_pv
-    | Identifier.AssetFile.t_pv ]
+  type any =
+    [ Identifier.Page.t
+    | Identifier.Signature.t
+    | Identifier.ClassSignature.t
+    | Identifier.SourcePage.t
+    | Identifier.AssetFile.t ]
 
-  and any = any_pv Odoc_model.Paths.Identifier.id
-
-  val from_identifier : [< any_pv ] Odoc_model.Paths.Identifier.id -> t
+  val from_identifier : [< any ] -> t
 
   val to_list : t -> (kind * string) list
 

--- a/src/index/entry.mli
+++ b/src/index/entry.mli
@@ -66,7 +66,7 @@ type t = {
 }
 
 val entry :
-  id:[< Odoc_model.Paths.Identifier.Any.t_pv ] Odoc_model.Paths.Identifier.id ->
+  id:[< Odoc_model.Paths.Identifier.Any.t ] ->
   doc:Odoc_model.Comment.elements ->
   kind:kind ->
   t

--- a/src/index/in_progress.ml
+++ b/src/index/in_progress.ml
@@ -32,7 +32,7 @@ let empty_t dir_id =
 
 let get_parent id : container_page option =
   let id :> page = id in
-  match id.iv with
+  match id with
   | `Page (Some parent, _) -> Some parent
   | `LeafPage (Some parent, _) -> Some parent
   | `Page (None, _) | `LeafPage (None, _) -> None
@@ -77,9 +77,9 @@ let rec get_or_create (dir : in_progress) (id : container_page) : in_progress =
 let add_page (dir : in_progress) page =
   let id =
     match page.Lang.Page.name with
-    | { iv = #Id.ContainerPage.t_pv; _ } as id ->
+    | #Id.ContainerPage.t as id ->
         Id.Mk.leaf_page (Some id, PageName.make_std "index")
-    | { iv = #Id.LeafPage.t_pv; _ } as id -> id
+    | #Id.LeafPage.t as id -> id
   in
   let _, dir_content =
     match get_parent id with
@@ -90,7 +90,7 @@ let add_page (dir : in_progress) page =
 
 let add_module (dir : in_progress) m =
   let _, dir_content =
-    match m.Lang.Compilation_unit.id.iv with
+    match m.Lang.Compilation_unit.id with
     | `Root (Some parent, _) -> get_or_create dir parent
     | `Root (None, _) -> dir
   in
@@ -100,7 +100,7 @@ let add_module (dir : in_progress) m =
 let add_implementation (dir : in_progress) (i : Lang.Implementation.t) =
   match i.id with
   | None -> ()
-  | Some ({ iv = `SourcePage (parent, _); _ } as id) ->
+  | Some (`SourcePage (parent, _) as id) ->
       let _, dir_content = get_or_create dir parent in
       SPH.replace dir_content.implementations id i
 

--- a/src/index/skeleton_of.ml
+++ b/src/index/skeleton_of.ml
@@ -25,7 +25,7 @@ let compare_entry (t1 : t) (t2 : t) =
     match t.node.kind with
     | Page { short_title = Some title; _ } -> Comment.to_string title
     | _ -> (
-        match t.node.id.iv with
+        match t.node.id with
         | `LeafPage (Some parent, name)
           when Names.PageName.to_string name = "index" ->
             Id.name parent
@@ -72,7 +72,7 @@ let rec t_of_in_progress (dir : In_progress.in_progress) : t =
         (None, entry)
   in
   let pp_content fmt (id, _) =
-    match id.Id.iv with
+    match id with
     | `LeafPage (_, name) -> Format.fprintf fmt "'%s'" (PageName.to_string name)
     | `Page (_, name) -> Format.fprintf fmt "'%s/'" (PageName.to_string name)
     | `Root (_, name) ->
@@ -118,7 +118,7 @@ let rec t_of_in_progress (dir : In_progress.in_progress) : t =
           List.mapi (fun i x -> (i, x)) children_order.value
         in
         let equal id ch =
-          match (ch, id.Id.iv) with
+          match (ch, id) with
           | (_, { Location_.value = Frontmatter.Dir c; _ }), `Page (_, name) ->
               Astring.String.equal (PageName.to_string name) c
           | (_, { Location_.value = Page c; _ }), `LeafPage (_, name) ->

--- a/src/loader/cmi.ml
+++ b/src/loader/cmi.ml
@@ -1289,7 +1289,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
           if Env.is_shadowed env.ident_env id
           then
             let identifier = Env.find_value_identifier env.ident_env id in
-          match identifier.iv with
+          match identifier with
           | `Value (_, n) -> { shadowed with s_values = (Odoc_model.Names.parenthesise (Ident.name id), n) :: shadowed.s_values }
           else shadowed
         in
@@ -1303,7 +1303,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
           if Env.is_shadowed env.ident_env id
           then
             let identifier = Env.find_type_identifier env.ident_env id in
-            let `Type (_, name) = identifier.iv in
+            let `Type (_, name) = identifier in
             { shadowed with s_types = (Ident.name id, name) :: shadowed.s_types }
           else shadowed
         in
@@ -1332,7 +1332,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
             then
               let identifier = Env.find_module_identifier env.ident_env id in
             let name =
-              match identifier.iv with
+              match identifier with
               | `Module (_, n) -> n 
               | `Parameter (_, n) -> n
               | `Root (_, n) -> n
@@ -1348,7 +1348,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
             then
               let identifier = Env.find_module_type env.ident_env id in
             let name =
-              match identifier.iv with
+              match identifier with
               | `ModuleType (_, n) -> n
             in
 
@@ -1369,7 +1369,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
             then
               let identifier = Env.find_class_identifier env.ident_env id in
             let name =
-              match identifier.iv with
+              match identifier with
               | `Class (_, n) -> n
             in
 
@@ -1388,7 +1388,7 @@ and read_signature_noenv env parent (items : Odoc_model.Compat.signature) =
           then
             let identifier = Env.find_class_type_identifier env.ident_env id in
           let name =
-            match identifier.iv with
+            match identifier with
             | `ClassType (_, n) -> n
           in
 { shadowed with s_class_types = (Ident.name id, name) :: shadowed.s_class_types }

--- a/src/loader/cmt.ml
+++ b/src/loader/cmt.ml
@@ -497,7 +497,7 @@ and read_module_binding env parent mb =
   in
   let canonical = match canonical with | None -> None | Some s -> Some (Doc_attr.conv_canonical_module s) in
   let hidden =
-    match canonical, mid.iv with
+    match canonical, mid with
     | None, (`Module (_, n) | `Parameter (_, n) | `Root (_, n)) -> Odoc_model.Names.ModuleName.is_hidden n
     | Some _, _ -> false
   in

--- a/src/loader/cmti.ml
+++ b/src/loader/cmti.ml
@@ -778,11 +778,11 @@ and read_module_declaration env parent md =
   let canonical = match canonical with | None -> None | Some s -> Some (Doc_attr.conv_canonical_module s) in
   let hidden =
 #if OCAML_VERSION >= (4,10,0)
-    match canonical, mid.iv with
+    match canonical, mid with
     | None, (`Module (_, n) | `Parameter (_, n) | `Root (_, n)) -> Odoc_model.Names.ModuleName.is_hidden n
     | _,_ -> false
 #else
-    match canonical, mid.iv with
+    match canonical, mid with
     | None, (`Module (_, n) | `Parameter (_, n) | `Root (_, n)) -> Odoc_model.Names.ModuleName.is_hidden n
     | _ -> false
 #endif

--- a/src/loader/implementation.ml
+++ b/src/loader/implementation.ml
@@ -203,13 +203,13 @@ let anchor_of_identifier id =
     let anchor kind name =
       Printf.sprintf "%s-%s" (Anchor.string_of_kind kind) name
     in
-    match id.iv with
+    match id with
     | `InstanceVariable (parent, name) ->
         let anchor = anchor `Val (InstanceVariableName.to_string name) in
         continue anchor parent
     | `Parameter (parent, name) as iv ->
         let arg_num =
-          Identifier.FunctorParameter.functor_arg_pos { Identifier.iv }
+          Identifier.FunctorParameter.functor_arg_pos iv
         in
         let kind = `Parameter arg_num in
         let anchor = anchor kind (ModuleName.to_string name) in

--- a/src/loader/implementation.ml
+++ b/src/loader/implementation.ml
@@ -209,7 +209,7 @@ let anchor_of_identifier id =
         continue anchor parent
     | `Parameter (parent, name) as iv ->
         let arg_num =
-          Identifier.FunctorParameter.functor_arg_pos { id with iv }
+          Identifier.FunctorParameter.functor_arg_pos { Identifier.iv }
         in
         let kind = `Parameter arg_num in
         let anchor = anchor kind (ModuleName.to_string name) in

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -20,17 +20,13 @@ module Ocaml_env = Env
 open Names
 
 module Identifier = struct
-  type 'a id = 'a Paths_types.id = { iv : 'a }
-
   module Id = Paths_types.Identifier
 
   type t = Id.any
 
-  type t_pv = Id.any_pv
-
   let rec name_aux : t -> string =
    fun x ->
-    match x.iv with
+    match x with
     | `Root (_, name) -> ModuleName.to_string name
     | `Page (_, name) -> PageName.to_string name
     | `LeafPage (_, name) -> PageName.to_string name
@@ -61,7 +57,7 @@ module Identifier = struct
 
   let rec is_hidden : t -> bool =
    fun x ->
-    match x.iv with
+    match x with
     | `Root (_, name) -> ModuleName.is_hidden name
     | `Page (_, _) -> false
     | `LeafPage (_, _) -> false
@@ -86,11 +82,11 @@ module Identifier = struct
     | `SourceLocationInternal _ | `AssetFile _ ->
         false
 
-  let name : [< t_pv ] id -> string = fun n -> name_aux (n :> t)
+  let name : [< t ] -> string = fun n -> name_aux (n :> t)
 
   let rec full_name_aux : t -> string list =
    fun x ->
-    match x.iv with
+    match x with
     | `Root (_, name) -> [ ModuleName.to_string name ]
     | `Page (None, name) -> [ PageName.to_string name ]
     | `Page (Some parent, name) ->
@@ -140,36 +136,36 @@ module Identifier = struct
     | `AssetFile (parent, name) ->
         AssetName.to_string name :: full_name_aux (parent :> t)
 
-  let fullname : [< t_pv ] id -> string list =
+  let fullname : [< t ] -> string list =
    fun n -> List.rev @@ full_name_aux (n :> t)
 
-  let is_hidden : [< t_pv ] id -> bool = fun n -> is_hidden (n :> t)
+  let is_hidden : [< t ] -> bool = fun n -> is_hidden (n :> t)
 
   let rec label_parent_aux =
     let open Id in
     fun (n : non_src) ->
       match n with
-      | { iv = `Result i; _ } -> label_parent_aux (i :> non_src)
-      | { iv = `Root _; _ } as p -> (p :> label_parent)
-      | { iv = `Page _; _ } as p -> (p :> label_parent)
-      | { iv = `LeafPage _; _ } as p -> (p :> label_parent)
-      | { iv = `Module (p, _); _ }
-      | { iv = `ModuleType (p, _); _ }
-      | { iv = `Parameter (p, _); _ }
-      | { iv = `Class (p, _); _ }
-      | { iv = `ClassType (p, _); _ }
-      | { iv = `Type (p, _); _ }
-      | { iv = `Extension (p, _); _ }
-      | { iv = `ExtensionDecl (p, _, _); _ }
-      | { iv = `Exception (p, _); _ }
-      | { iv = `Value (p, _); _ } ->
+      | `Result i -> label_parent_aux (i :> non_src)
+      | `Root _ as p -> (p :> label_parent)
+      | `Page _ as p -> (p :> label_parent)
+      | `LeafPage _ as p -> (p :> label_parent)
+      | `Module (p, _)
+      | `ModuleType (p, _)
+      | `Parameter (p, _)
+      | `Class (p, _)
+      | `ClassType (p, _)
+      | `Type (p, _)
+      | `Extension (p, _)
+      | `ExtensionDecl (p, _, _)
+      | `Exception (p, _)
+      | `Value (p, _) ->
           (p : signature :> label_parent)
-      | { iv = `Label (p, _); _ } -> p
-      | { iv = `Method (p, _); _ } | { iv = `InstanceVariable (p, _); _ } ->
+      | `Label (p, _) -> p
+      | `Method (p, _) | `InstanceVariable (p, _) ->
           (p : class_signature :> label_parent)
-      | { iv = `Constructor (p, _); _ } -> (p : datatype :> label_parent)
-      | { iv = `Field (p, _); _ } -> (p : field_parent :> label_parent)
-      | { iv = `UnboxedField (p, _); _ } ->
+      | `Constructor (p, _) -> (p : datatype :> label_parent)
+      | `Field (p, _) -> (p : field_parent :> label_parent)
+      | `UnboxedField (p, _) ->
           (p : unboxed_field_parent :> label_parent)
 
   let label_parent n = label_parent_aux (n :> Id.non_src)
@@ -189,15 +185,14 @@ module Identifier = struct
      values are silently ignored and cannot help. *)
   let hash x = Hashtbl.hash_param 256 256 x
 
-  let compare x y = if x == y then 0 else compare x.iv y.iv
+  (* Left polymorphic on purpose: every sub-module below reuses this as its
+     own [compare], each at a narrower identifier type. *)
+  let compare = Stdlib.compare
 
   type any = t
 
-  type any_pv = t_pv
-
   module type IdSig = sig
     type t
-    type t_pv
     val equal : t -> t -> bool
     val hash : t -> int
     val compare : t -> t -> int
@@ -205,7 +200,6 @@ module Identifier = struct
 
   module Any = struct
     type t = any
-    type t_pv = any_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -213,7 +207,6 @@ module Identifier = struct
 
   module Signature = struct
     type t = Id.signature
-    type t_pv = Id.signature_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -221,7 +214,6 @@ module Identifier = struct
 
   module ClassSignature = struct
     type t = Id.class_signature
-    type t_pv = Id.class_signature_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -229,22 +221,18 @@ module Identifier = struct
 
   module DataType = struct
     type t = Id.datatype
-    type t_pv = Id.datatype_pv
   end
 
   module FieldParent = struct
     type t = Paths_types.Identifier.field_parent
-    type t_pv = Paths_types.Identifier.field_parent_pv
   end
 
   module UnboxedFieldParent = struct
     type t = Paths_types.Identifier.unboxed_field_parent
-    type t_pv = Paths_types.Identifier.unboxed_field_parent_pv
   end
 
   module LabelParent = struct
     type t = Id.label_parent
-    type t_pv = Id.label_parent_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -252,7 +240,6 @@ module Identifier = struct
 
   module RootModule = struct
     type t = Id.root_module
-    type t_pv = Id.root_module_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -260,7 +247,6 @@ module Identifier = struct
 
   module Module = struct
     type t = Id.module_
-    type t_pv = Id.module_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -268,27 +254,24 @@ module Identifier = struct
 
   module FunctorParameter = struct
     type t = Id.functor_parameter
-    type t_pv = Id.functor_parameter_pv
     let equal = equal
     let hash = hash
     let compare = compare
 
-    let functor_arg_pos { iv = `Parameter (p, _); _ } =
+    let functor_arg_pos (`Parameter (p, _)) =
       let rec inner_sig = function
-        | `Result { iv = p; _ } -> 1 + inner_sig p
+        | `Result p -> 1 + inner_sig p
         | `Module _ | `ModuleType _ | `Root _ | `Parameter _ -> 1
       in
-      inner_sig p.iv
+      inner_sig p
   end
 
   module FunctorResult = struct
     type t = Id.functor_result
-    type t_pv = Id.functor_result_pv
   end
 
   module ModuleType = struct
     type t = Id.module_type
-    type t_pv = Id.module_type_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -296,7 +279,6 @@ module Identifier = struct
 
   module Type = struct
     type t = Id.type_
-    type t_pv = Id.type_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -304,28 +286,22 @@ module Identifier = struct
 
   module Constructor = struct
     type t = Id.constructor
-    type t_pv = Id.constructor_pv
   end
 
   module Field = struct
     type t = Id.field
-    type t_pv = Id.field_pv
   end
 
   module UnboxedField = struct
     type t = Id.unboxed_field
-    type t_pv = Id.unboxed_field_pv
   end
 
   module Extension = struct
     type t = Id.extension
-    type t_pv = Id.extension_pv
   end
 
   module ExtensionDecl = struct
     type t = Paths_types.Identifier.extension_decl
-
-    type t_pv = Paths_types.Identifier.extension_decl_pv
 
     let equal = equal
 
@@ -336,17 +312,14 @@ module Identifier = struct
 
   module Exception = struct
     type t = Id.exception_
-    type t_pv = Id.exception_pv
   end
 
   module Value = struct
     type t = Id.value
-    type t_pv = Id.value_pv
   end
 
   module Class = struct
     type t = Id.class_
-    type t_pv = Id.class_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -354,7 +327,6 @@ module Identifier = struct
 
   module ClassType = struct
     type t = Id.class_type
-    type t_pv = Id.class_type_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -362,17 +334,14 @@ module Identifier = struct
 
   module Method = struct
     type t = Id.method_
-    type t_pv = Id.method_pv
   end
 
   module InstanceVariable = struct
     type t = Id.instance_variable
-    type t_pv = Id.instance_variable_pv
   end
 
   module Label = struct
     type t = Paths_types.Identifier.label
-    type t_pv = Paths_types.Identifier.label_pv
     let equal = equal
     let hash = hash
     let compare = compare
@@ -380,26 +349,22 @@ module Identifier = struct
 
   module Page = struct
     type t = Id.page
-    type t_pv = Id.page_pv
   end
 
   module LeafPage = struct
     type t = Id.leaf_page
-    type t_pv = Id.leaf_page_pv
     let equal = equal
     let hash = hash
   end
 
   module ContainerPage = struct
     type t = Id.container_page
-    type t_pv = Id.container_page_pv
     let equal = equal
     let hash = hash
   end
 
   module NonSrc = struct
     type t = Paths_types.Identifier.non_src
-    type t_pv = Paths_types.Identifier.non_src_pv
 
     (* [==] guard as in [equal] above: [( = )] alone never checks pointers. *)
     let equal x y = x == y || x = y
@@ -409,7 +374,6 @@ module Identifier = struct
 
   module SourcePage = struct
     type t = Id.source_page
-    type t_pv = Id.source_page_pv
 
     let equal = equal
     let hash = hash
@@ -417,23 +381,19 @@ module Identifier = struct
 
   module SourceLocation = struct
     type t = Paths_types.Identifier.source_location
-    type t_pv = Paths_types.Identifier.source_location_pv
   end
 
   module AssetFile = struct
     type t = Id.asset_file
-    type t_pv = Id.asset_file_pv
   end
 
   module OdocId = struct
     type t = Id.odoc_id
-    type t_pv = Id.odoc_id_pv
   end
 
   module Path = struct
     module Module = struct
       type t = Id.path_module
-      type t_pv = Id.path_module_pv
       let equal = equal
       let hash = hash
       let compare = compare
@@ -441,7 +401,6 @@ module Identifier = struct
 
     module ModuleType = struct
       type t = Id.path_module_type
-      type t_pv = Id.module_type_pv
       let equal = equal
       let hash = hash
       let compare = compare
@@ -449,7 +408,6 @@ module Identifier = struct
 
     module Type = struct
       type t = Id.path_type
-      type t_pv = Id.path_type_pv
       let equal = equal
       let hash = hash
       let compare = compare
@@ -457,7 +415,6 @@ module Identifier = struct
 
     module Value = struct
       type t = Id.path_value
-      type t_pv = Id.value_pv
       let equal = equal
       let hash = hash
       let compare = compare
@@ -465,7 +422,6 @@ module Identifier = struct
 
     module ClassType = struct
       type t = Id.path_class_type
-      type t_pv = Id.path_class_type_pv
       let equal = equal
       let hash = hash
       let compare = compare
@@ -493,16 +449,16 @@ module Identifier = struct
   end
 
   module Mk = struct
-    let mk f x = { iv = f x }
+    let mk f x = f x
 
     let page :
         ContainerPage.t option * PageName.t ->
-        [> `Page of ContainerPage.t option * PageName.t ] id =
+        [> `Page of ContainerPage.t option * PageName.t ] =
       mk (fun (p, n) -> `Page (p, n))
 
     let leaf_page :
         ContainerPage.t option * PageName.t ->
-        [> `LeafPage of ContainerPage.t option * PageName.t ] id =
+        [> `LeafPage of ContainerPage.t option * PageName.t ] =
       mk (fun (p, n) -> `LeafPage (p, n))
 
     let asset_file : Page.t * AssetName.t -> AssetFile.t =
@@ -513,107 +469,106 @@ module Identifier = struct
 
     let root :
         ContainerPage.t option * ModuleName.t ->
-        [> `Root of ContainerPage.t option * ModuleName.t ] id =
+        [> `Root of ContainerPage.t option * ModuleName.t ] =
       mk (fun (p, n) -> `Root (p, n))
 
     let implementation = mk (fun s -> `Implementation (ModuleName.make_std s))
 
     let module_ :
         Signature.t * ModuleName.t ->
-        [> `Module of Signature.t * ModuleName.t ] id =
+        [> `Module of Signature.t * ModuleName.t ] =
       mk (fun (p, n) -> `Module (p, n))
 
     let parameter :
         Signature.t * ModuleName.t ->
-        [> `Parameter of Signature.t * ModuleName.t ] id =
+        [> `Parameter of Signature.t * ModuleName.t ] =
       mk (fun (p, n) -> `Parameter (p, n))
 
-    let result : Signature.t -> [> `Result of Signature.t ] id =
+    let result : Signature.t -> [> `Result of Signature.t ] =
      fun s -> mk (fun s -> `Result s) s
 
     let module_type :
         Signature.t * ModuleTypeName.t ->
-        [> `ModuleType of Signature.t * ModuleTypeName.t ] id =
+        [> `ModuleType of Signature.t * ModuleTypeName.t ] =
       mk (fun (p, n) -> `ModuleType (p, n))
 
     let class_ :
-        Signature.t * TypeName.t -> [> `Class of Signature.t * TypeName.t ] id =
+        Signature.t * TypeName.t -> [> `Class of Signature.t * TypeName.t ] =
       mk (fun (p, n) -> `Class (p, n))
 
     let class_type :
         Signature.t * TypeName.t ->
-        [> `ClassType of Signature.t * TypeName.t ] id =
+        [> `ClassType of Signature.t * TypeName.t ] =
       mk (fun (p, n) -> `ClassType (p, n))
 
     let type_ :
-        Signature.t * TypeName.t -> [> `Type of Signature.t * TypeName.t ] id =
+        Signature.t * TypeName.t -> [> `Type of Signature.t * TypeName.t ] =
       mk (fun (p, n) -> `Type (p, n))
 
     let core_type = mk (fun s -> `CoreType (TypeName.make_std s))
 
     let constructor :
         DataType.t * ConstructorName.t ->
-        [> `Constructor of DataType.t * ConstructorName.t ] id =
+        [> `Constructor of DataType.t * ConstructorName.t ] =
       mk (fun (p, n) -> `Constructor (p, n))
 
     let field :
         FieldParent.t * FieldName.t ->
-        [> `Field of FieldParent.t * FieldName.t ] id =
+        [> `Field of FieldParent.t * FieldName.t ] =
       mk (fun (p, n) -> `Field (p, n))
 
     let unboxed_field :
         UnboxedFieldParent.t * UnboxedFieldName.t ->
-        [> `UnboxedField of UnboxedFieldParent.t * UnboxedFieldName.t ] id =
+        [> `UnboxedField of UnboxedFieldParent.t * UnboxedFieldName.t ] =
       mk (fun (p, n) -> `UnboxedField (p, n))
 
     let extension :
         Signature.t * ExtensionName.t ->
-        [> `Extension of Signature.t * ExtensionName.t ] id =
+        [> `Extension of Signature.t * ExtensionName.t ] =
       mk (fun (p, n) -> `Extension (p, n))
 
     let extension_decl :
         Signature.t * (ExtensionName.t * ExtensionName.t) ->
-        [> `ExtensionDecl of Signature.t * ExtensionName.t * ExtensionName.t ]
-        id =
+        [> `ExtensionDecl of Signature.t * ExtensionName.t * ExtensionName.t ] =
       mk (fun (p, (n, m)) -> `ExtensionDecl (p, n, m))
 
     let exception_ :
         Signature.t * ExceptionName.t ->
-        [> `Exception of Signature.t * ExceptionName.t ] id =
+        [> `Exception of Signature.t * ExceptionName.t ] =
       mk (fun (p, n) -> `Exception (p, n))
 
     let value :
-        Signature.t * ValueName.t -> [> `Value of Signature.t * ValueName.t ] id
+        Signature.t * ValueName.t -> [> `Value of Signature.t * ValueName.t ]
         =
       mk (fun (p, n) -> `Value (p, n))
 
     let method_ :
         ClassSignature.t * MethodName.t ->
-        [> `Method of ClassSignature.t * MethodName.t ] id =
+        [> `Method of ClassSignature.t * MethodName.t ] =
       mk (fun (p, n) -> `Method (p, n))
 
     let instance_variable :
         ClassSignature.t * InstanceVariableName.t ->
-        [> `InstanceVariable of ClassSignature.t * InstanceVariableName.t ] id =
+        [> `InstanceVariable of ClassSignature.t * InstanceVariableName.t ] =
       mk (fun (p, n) -> `InstanceVariable (p, n))
 
     let label :
         LabelParent.t * LabelName.t ->
-        [> `Label of LabelParent.t * LabelName.t ] id =
+        [> `Label of LabelParent.t * LabelName.t ] =
       mk (fun (p, n) -> `Label (p, n))
 
     let source_location :
         SourcePage.t * DefName.t ->
-        [> `SourceLocation of SourcePage.t * DefName.t ] id =
+        [> `SourceLocation of SourcePage.t * DefName.t ] =
       mk (fun (p, n) -> `SourceLocation (p, n))
 
     let source_location_mod :
-        SourcePage.t -> [> `SourceLocationMod of SourcePage.t ] id =
+        SourcePage.t -> [> `SourceLocationMod of SourcePage.t ] =
      fun s -> mk (fun s -> `SourceLocationMod s) s
 
     let source_location_int :
         SourcePage.t * LocalName.t ->
-        [> `SourceLocationInternal of SourcePage.t * LocalName.t ] id =
+        [> `SourceLocationInternal of SourcePage.t * LocalName.t ] =
       mk (fun (p, n) -> `SourceLocationInternal (p, n))
   end
 
@@ -657,12 +612,12 @@ module Path = struct
    fun ~weak_canonical_test x ->
     let open Paths_types.Resolved_path in
     let rec inner : Paths_types.Resolved_path.any -> bool = function
-      | `Identifier { iv = `ModuleType (_, m); _ }
+      | `Identifier `ModuleType (_, m)
         when Names.ModuleTypeName.is_hidden m ->
           true
-      | `Identifier { iv = `Type (_, t); _ } when Names.TypeName.is_hidden t ->
+      | `Identifier `Type (_, t) when Names.TypeName.is_hidden t ->
           true
-      | `Identifier { iv = `Module (_, m); _ } when Names.ModuleName.is_hidden m
+      | `Identifier `Module (_, m) when Names.ModuleName.is_hidden m
         ->
           true
       | `Identifier id -> Identifier.is_hidden id

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -165,8 +165,7 @@ module Identifier = struct
           (p : class_signature :> label_parent)
       | `Constructor (p, _) -> (p : datatype :> label_parent)
       | `Field (p, _) -> (p : field_parent :> label_parent)
-      | `UnboxedField (p, _) ->
-          (p : unboxed_field_parent :> label_parent)
+      | `UnboxedField (p, _) -> (p : unboxed_field_parent :> label_parent)
 
   let label_parent n = label_parent_aux (n :> Id.non_src)
 
@@ -475,8 +474,8 @@ module Identifier = struct
     let implementation = mk (fun s -> `Implementation (ModuleName.make_std s))
 
     let module_ :
-        Signature.t * ModuleName.t ->
-        [> `Module of Signature.t * ModuleName.t ] =
+        Signature.t * ModuleName.t -> [> `Module of Signature.t * ModuleName.t ]
+        =
       mk (fun (p, n) -> `Module (p, n))
 
     let parameter :
@@ -497,8 +496,8 @@ module Identifier = struct
       mk (fun (p, n) -> `Class (p, n))
 
     let class_type :
-        Signature.t * TypeName.t ->
-        [> `ClassType of Signature.t * TypeName.t ] =
+        Signature.t * TypeName.t -> [> `ClassType of Signature.t * TypeName.t ]
+        =
       mk (fun (p, n) -> `ClassType (p, n))
 
     let type_ :
@@ -513,8 +512,8 @@ module Identifier = struct
       mk (fun (p, n) -> `Constructor (p, n))
 
     let field :
-        FieldParent.t * FieldName.t ->
-        [> `Field of FieldParent.t * FieldName.t ] =
+        FieldParent.t * FieldName.t -> [> `Field of FieldParent.t * FieldName.t ]
+        =
       mk (fun (p, n) -> `Field (p, n))
 
     let unboxed_field :
@@ -538,8 +537,7 @@ module Identifier = struct
       mk (fun (p, n) -> `Exception (p, n))
 
     let value :
-        Signature.t * ValueName.t -> [> `Value of Signature.t * ValueName.t ]
-        =
+        Signature.t * ValueName.t -> [> `Value of Signature.t * ValueName.t ] =
       mk (fun (p, n) -> `Value (p, n))
 
     let method_ :
@@ -553,8 +551,8 @@ module Identifier = struct
       mk (fun (p, n) -> `InstanceVariable (p, n))
 
     let label :
-        LabelParent.t * LabelName.t ->
-        [> `Label of LabelParent.t * LabelName.t ] =
+        LabelParent.t * LabelName.t -> [> `Label of LabelParent.t * LabelName.t ]
+        =
       mk (fun (p, n) -> `Label (p, n))
 
     let source_location :
@@ -612,14 +610,11 @@ module Path = struct
    fun ~weak_canonical_test x ->
     let open Paths_types.Resolved_path in
     let rec inner : Paths_types.Resolved_path.any -> bool = function
-      | `Identifier `ModuleType (_, m)
-        when Names.ModuleTypeName.is_hidden m ->
-          true
-      | `Identifier `Type (_, t) when Names.TypeName.is_hidden t ->
-          true
-      | `Identifier `Module (_, m) when Names.ModuleName.is_hidden m
+      | `Identifier (`ModuleType (_, m)) when Names.ModuleTypeName.is_hidden m
         ->
           true
+      | `Identifier (`Type (_, t)) when Names.TypeName.is_hidden t -> true
+      | `Identifier (`Module (_, m)) when Names.ModuleName.is_hidden m -> true
       | `Identifier id -> Identifier.is_hidden id
       | `Canonical (_, `Resolved _) -> false
       | `Canonical (x, _) ->

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -728,6 +728,18 @@ module Path = struct
 
       let is_hidden m =
         is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
+
+      (* Same policy as [Identifier.equal]/[Identifier.hash] - see the comment
+         there for why [Hashtbl.hash] is too shallow for these spines. *)
+      let equal x y = x == y || x = y
+      let hash x = Hashtbl.hash_param 256 256 x
+
+      module Hashtbl = Hashtbl.Make (struct
+        type nonrec t = t
+
+        let equal = equal
+        let hash = hash
+      end)
     end
 
     module ModuleType = struct

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -20,7 +20,7 @@ module Ocaml_env = Env
 open Names
 
 module Identifier = struct
-  type 'a id = 'a Paths_types.id = { iv : 'a; ihash : int; ikey : string }
+  type 'a id = 'a Paths_types.id = { iv : 'a }
 
   module Id = Paths_types.Identifier
 
@@ -174,11 +174,22 @@ module Identifier = struct
 
   let label_parent n = label_parent_aux (n :> Id.non_src)
 
-  let equal x y = x.ihash = y.ihash && x.ikey = y.ikey
+  (* An identifier is now just plain data, so structural equality is the right
+     notion. *)
+  let equal x y = x == y || x = y
 
-  let hash x = x.ihash
+  (* Deliberately not [Hashtbl.hash], which is [hash_param 10 100]. Hashing is a
+     breadth-first walk that stops after [count] meaningful nodes (ints,
+     strings) or [limit] enqueued ones, and each identifier level costs several
+     of each, so a budget of 10 is exhausted a few levels down and never reaches
+     the root.
 
-  let compare x y = compare x.ikey y.ikey
+     256/256 is the most reach obtainable: the runtime clamps [limit] to its
+     fixed-size traversal queue (HASH_QUEUE_SIZE, runtime/hash.c), so larger
+     values are silently ignored and cannot help. *)
+  let hash x = Hashtbl.hash_param 256 256 x
+
+  let compare x y = if x == y then 0 else compare x.iv y.iv
 
   type any = t
 
@@ -390,9 +401,10 @@ module Identifier = struct
     type t = Paths_types.Identifier.non_src
     type t_pv = Paths_types.Identifier.non_src_pv
 
-    let equal x y = x.ihash = y.ihash && x.ikey = y.ikey
+    (* [==] guard as in [equal] above: [( = )] alone never checks pointers. *)
+    let equal x y = x == y || x = y
 
-    let hash x = x.ihash
+    let hash x = Hashtbl.hash_param 256 256 x
   end
 
   module SourcePage = struct
@@ -481,169 +493,128 @@ module Identifier = struct
   end
 
   module Mk = struct
-    let mk_fresh to_str ty f x =
-      let ikey = Printf.sprintf "%s_%s" ty (to_str x) in
-      let ihash = Hashtbl.hash ikey in
-      { iv = f x; ihash; ikey }
-
-    let mk_parent to_str ty f (parent, x) =
-      let ikey = Printf.sprintf "%s_%s.%s" ty (to_str x) parent.ikey in
-      let ihash = Hashtbl.hash ikey in
-
-      { iv = f (parent, x); ihash; ikey }
-
-    let mk_parent_opt to_str ty f (parent_opt, x) =
-      let ikey =
-        match parent_opt with
-        | None -> Printf.sprintf "%s_%s" ty (to_str x)
-        | Some p -> Printf.sprintf "%s_%s.%s" ty (to_str x) p.ikey
-      in
-      let ihash = Hashtbl.hash ikey in
-      { iv = f (parent_opt, x); ihash; ikey }
+    let mk f x = { iv = f x }
 
     let page :
         ContainerPage.t option * PageName.t ->
         [> `Page of ContainerPage.t option * PageName.t ] id =
-      mk_parent_opt PageName.to_string "p" (fun (p, n) -> `Page (p, n))
+      mk (fun (p, n) -> `Page (p, n))
 
     let leaf_page :
         ContainerPage.t option * PageName.t ->
         [> `LeafPage of ContainerPage.t option * PageName.t ] id =
-      mk_parent_opt PageName.to_string "lp" (fun (p, n) -> `LeafPage (p, n))
+      mk (fun (p, n) -> `LeafPage (p, n))
 
     let asset_file : Page.t * AssetName.t -> AssetFile.t =
-      mk_parent AssetName.to_string "asset" (fun (p, n) -> `AssetFile (p, n))
+      mk (fun (p, n) -> `AssetFile (p, n))
 
     let source_page (container_page, name) =
-      mk_parent
-        (fun x -> x)
-        "sp"
-        (fun (p, rp) -> `SourcePage (p, rp))
-        (container_page, name)
+      mk (fun (p, rp) -> `SourcePage (p, rp)) (container_page, name)
 
     let root :
         ContainerPage.t option * ModuleName.t ->
         [> `Root of ContainerPage.t option * ModuleName.t ] id =
-      mk_parent_opt ModuleName.to_string "r" (fun (p, n) -> `Root (p, n))
+      mk (fun (p, n) -> `Root (p, n))
 
-    let implementation =
-      mk_fresh
-        (fun s -> s)
-        "impl"
-        (fun s -> `Implementation (ModuleName.make_std s))
+    let implementation = mk (fun s -> `Implementation (ModuleName.make_std s))
 
     let module_ :
         Signature.t * ModuleName.t ->
         [> `Module of Signature.t * ModuleName.t ] id =
-      mk_parent ModuleName.to_string "m" (fun (p, n) -> `Module (p, n))
+      mk (fun (p, n) -> `Module (p, n))
 
     let parameter :
         Signature.t * ModuleName.t ->
         [> `Parameter of Signature.t * ModuleName.t ] id =
-      mk_parent ModuleName.to_string "p" (fun (p, n) -> `Parameter (p, n))
+      mk (fun (p, n) -> `Parameter (p, n))
 
     let result : Signature.t -> [> `Result of Signature.t ] id =
-     fun s ->
-      mk_parent (fun () -> "__result__") "" (fun (s, ()) -> `Result s) (s, ())
+     fun s -> mk (fun s -> `Result s) s
 
     let module_type :
         Signature.t * ModuleTypeName.t ->
         [> `ModuleType of Signature.t * ModuleTypeName.t ] id =
-      mk_parent ModuleTypeName.to_string "mt" (fun (p, n) -> `ModuleType (p, n))
+      mk (fun (p, n) -> `ModuleType (p, n))
 
     let class_ :
         Signature.t * TypeName.t -> [> `Class of Signature.t * TypeName.t ] id =
-      mk_parent TypeName.to_string "c" (fun (p, n) -> `Class (p, n))
+      mk (fun (p, n) -> `Class (p, n))
 
     let class_type :
         Signature.t * TypeName.t ->
         [> `ClassType of Signature.t * TypeName.t ] id =
-      mk_parent TypeName.to_string "ct" (fun (p, n) -> `ClassType (p, n))
+      mk (fun (p, n) -> `ClassType (p, n))
 
     let type_ :
         Signature.t * TypeName.t -> [> `Type of Signature.t * TypeName.t ] id =
-      mk_parent TypeName.to_string "t" (fun (p, n) -> `Type (p, n))
+      mk (fun (p, n) -> `Type (p, n))
 
-    let core_type =
-      mk_fresh (fun s -> s) "coret" (fun s -> `CoreType (TypeName.make_std s))
+    let core_type = mk (fun s -> `CoreType (TypeName.make_std s))
 
     let constructor :
         DataType.t * ConstructorName.t ->
         [> `Constructor of DataType.t * ConstructorName.t ] id =
-      mk_parent ConstructorName.to_string "ctor" (fun (p, n) ->
-          `Constructor (p, n))
+      mk (fun (p, n) -> `Constructor (p, n))
 
     let field :
         FieldParent.t * FieldName.t ->
         [> `Field of FieldParent.t * FieldName.t ] id =
-      mk_parent FieldName.to_string "fld" (fun (p, n) -> `Field (p, n))
+      mk (fun (p, n) -> `Field (p, n))
 
     let unboxed_field :
         UnboxedFieldParent.t * UnboxedFieldName.t ->
         [> `UnboxedField of UnboxedFieldParent.t * UnboxedFieldName.t ] id =
-      mk_parent UnboxedFieldName.to_string "unboxedfld" (fun (p, n) ->
-          `UnboxedField (p, n))
+      mk (fun (p, n) -> `UnboxedField (p, n))
 
     let extension :
         Signature.t * ExtensionName.t ->
         [> `Extension of Signature.t * ExtensionName.t ] id =
-      mk_parent ExtensionName.to_string "extn" (fun (p, n) -> `Extension (p, n))
+      mk (fun (p, n) -> `Extension (p, n))
 
     let extension_decl :
         Signature.t * (ExtensionName.t * ExtensionName.t) ->
         [> `ExtensionDecl of Signature.t * ExtensionName.t * ExtensionName.t ]
         id =
-      mk_parent
-        (fun (n, m) ->
-          ExtensionName.to_string n ^ "." ^ ExtensionName.to_string m)
-        "extn-decl"
-        (fun (p, (n, m)) -> `ExtensionDecl (p, n, m))
+      mk (fun (p, (n, m)) -> `ExtensionDecl (p, n, m))
 
     let exception_ :
         Signature.t * ExceptionName.t ->
         [> `Exception of Signature.t * ExceptionName.t ] id =
-      mk_parent ExceptionName.to_string "exn" (fun (p, n) -> `Exception (p, n))
+      mk (fun (p, n) -> `Exception (p, n))
 
     let value :
         Signature.t * ValueName.t -> [> `Value of Signature.t * ValueName.t ] id
         =
-      mk_parent ValueName.to_string "v" (fun (p, n) -> `Value (p, n))
+      mk (fun (p, n) -> `Value (p, n))
 
     let method_ :
         ClassSignature.t * MethodName.t ->
         [> `Method of ClassSignature.t * MethodName.t ] id =
-      mk_parent MethodName.to_string "m" (fun (p, n) -> `Method (p, n))
+      mk (fun (p, n) -> `Method (p, n))
 
     let instance_variable :
         ClassSignature.t * InstanceVariableName.t ->
         [> `InstanceVariable of ClassSignature.t * InstanceVariableName.t ] id =
-      mk_parent InstanceVariableName.to_string "iv" (fun (p, n) ->
-          `InstanceVariable (p, n))
+      mk (fun (p, n) -> `InstanceVariable (p, n))
 
     let label :
         LabelParent.t * LabelName.t ->
         [> `Label of LabelParent.t * LabelName.t ] id =
-      mk_parent LabelName.to_string "l" (fun (p, n) -> `Label (p, n))
+      mk (fun (p, n) -> `Label (p, n))
 
     let source_location :
         SourcePage.t * DefName.t ->
         [> `SourceLocation of SourcePage.t * DefName.t ] id =
-      mk_parent DefName.to_string "sl" (fun (p, n) -> `SourceLocation (p, n))
+      mk (fun (p, n) -> `SourceLocation (p, n))
 
     let source_location_mod :
         SourcePage.t -> [> `SourceLocationMod of SourcePage.t ] id =
-     fun s ->
-      mk_parent
-        (fun () -> "__slm__")
-        ""
-        (fun (s, ()) -> `SourceLocationMod s)
-        (s, ())
+     fun s -> mk (fun s -> `SourceLocationMod s) s
 
     let source_location_int :
         SourcePage.t * LocalName.t ->
         [> `SourceLocationInternal of SourcePage.t * LocalName.t ] id =
-      mk_parent LocalName.to_string "sli" (fun (p, n) ->
-          `SourceLocationInternal (p, n))
+      mk (fun (p, n) -> `SourceLocationInternal (p, n))
   end
 
   (* Counter for generating unique synthetic parents for include expressions.

--- a/src/model/paths.ml
+++ b/src/model/paths.ml
@@ -365,10 +365,8 @@ module Identifier = struct
   module NonSrc = struct
     type t = Paths_types.Identifier.non_src
 
-    (* [==] guard as in [equal] above: [( = )] alone never checks pointers. *)
-    let equal x y = x == y || x = y
-
-    let hash x = Hashtbl.hash_param 256 256 x
+    let equal = equal
+    let hash = hash
   end
 
   module SourcePage = struct
@@ -729,10 +727,10 @@ module Path = struct
       let is_hidden m =
         is_resolved_hidden (m : t :> Paths_types.Resolved_path.any)
 
-      (* Same policy as [Identifier.equal]/[Identifier.hash] - see the comment
-         there for why [Hashtbl.hash] is too shallow for these spines. *)
-      let equal x y = x == y || x = y
-      let hash x = Hashtbl.hash_param 256 256 x
+      (* [Identifier.equal]/[Identifier.hash] are polymorphic; the same policy
+         works for resolved-path spines. *)
+      let equal = Identifier.equal
+      let hash = Identifier.hash
 
       module Hashtbl = Hashtbl.Make (struct
         type nonrec t = t

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -22,7 +22,7 @@ module Ocaml_env = Env
 module Identifier : sig
   (** {2 Generic operations} *)
 
-  type 'a id = 'a Paths_types.id = { iv : 'a; ihash : int; ikey : string }
+  type 'a id = 'a Paths_types.id = { iv : 'a }
 
   module type IdSig = sig
     type t

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -333,6 +333,12 @@ module rec Path : sig
 
       val is_hidden : t -> weak_canonical_test:bool -> bool
 
+      val equal : t -> t -> bool
+
+      val hash : t -> int
+
+      module Hashtbl : Hashtbl.S with type key = t
+
       (* val identifier : t -> Identifier.Path.Module.t *)
 
       (* val root : t -> string option *)

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -33,24 +33,18 @@ module Identifier : sig
 
   module Any : IdSig with type t = Id.any
 
-  module RootModule :
-    IdSig with type t = Id.root_module
+  module RootModule : IdSig with type t = Id.root_module
 
-  module Signature :
-    IdSig with type t = Id.signature
+  module Signature : IdSig with type t = Id.signature
 
-  module ClassSignature :
-    IdSig with type t = Id.class_signature
+  module ClassSignature : IdSig with type t = Id.class_signature
 
-  module LabelParent :
-    IdSig with type t = Id.label_parent
+  module LabelParent : IdSig with type t = Id.label_parent
 
   module Module : IdSig with type t = Id.module_
 
   module FunctorParameter : sig
-    include
-      IdSig
-        with type t = Id.functor_parameter
+    include IdSig with type t = Id.functor_parameter
 
     val functor_arg_pos : t -> int
     (** Gets the index in which the functor argument is, in the argument list.
@@ -58,15 +52,13 @@ module Identifier : sig
         can have the same name. *)
   end
 
-  module ModuleType :
-    IdSig with type t = Id.module_type
+  module ModuleType : IdSig with type t = Id.module_type
 
   module Type : IdSig with type t = Id.type_
 
   module Class : IdSig with type t = Id.class_
 
-  module ClassType :
-    IdSig with type t = Id.class_type
+  module ClassType : IdSig with type t = Id.class_type
 
   module DataType : sig
     type t = Id.datatype
@@ -160,20 +152,15 @@ module Identifier : sig
   end
 
   module Path : sig
-    module Module :
-      IdSig with type t = Id.path_module
+    module Module : IdSig with type t = Id.path_module
 
-    module ModuleType :
-      IdSig with type t = Id.path_module_type
+    module ModuleType : IdSig with type t = Id.path_module_type
 
-    module Type :
-      IdSig with type t = Id.path_type
+    module Type : IdSig with type t = Id.path_type
 
     module Value : IdSig with type t = Id.path_value
 
-    module ClassType :
-      IdSig
-        with type t = Id.path_class_type
+    module ClassType : IdSig with type t = Id.path_class_type
 
     type t = Id.path_any
   end
@@ -250,12 +237,10 @@ module Identifier : sig
     val implementation : string -> [> `Implementation of ModuleName.t ]
 
     val module_ :
-      Signature.t * ModuleName.t ->
-      [> `Module of Signature.t * ModuleName.t ]
+      Signature.t * ModuleName.t -> [> `Module of Signature.t * ModuleName.t ]
 
     val parameter :
-      Signature.t * ModuleName.t ->
-      [> `Parameter of Signature.t * ModuleName.t ]
+      Signature.t * ModuleName.t -> [> `Parameter of Signature.t * ModuleName.t ]
 
     val result : Signature.t -> [> `Result of Signature.t ]
 
@@ -279,8 +264,7 @@ module Identifier : sig
       [> `Constructor of DataType.t * ConstructorName.t ]
 
     val field :
-      FieldParent.t * FieldName.t ->
-      [> `Field of FieldParent.t * FieldName.t ]
+      FieldParent.t * FieldName.t -> [> `Field of FieldParent.t * FieldName.t ]
 
     val unboxed_field :
       UnboxedFieldParent.t * UnboxedFieldName.t ->
@@ -315,8 +299,7 @@ module Identifier : sig
       [> `InstanceVariable of ClassSignature.t * InstanceVariableName.t ]
 
     val label :
-      LabelParent.t * LabelName.t ->
-      [> `Label of LabelParent.t * LabelName.t ]
+      LabelParent.t * LabelName.t -> [> `Label of LabelParent.t * LabelName.t ]
 
     val source_location :
       SourcePage.t * DefName.t ->

--- a/src/model/paths.mli
+++ b/src/model/paths.mli
@@ -22,11 +22,8 @@ module Ocaml_env = Env
 module Identifier : sig
   (** {2 Generic operations} *)
 
-  type 'a id = 'a Paths_types.id = { iv : 'a }
-
   module type IdSig = sig
     type t
-    type t_pv
     val equal : t -> t -> bool
     val hash : t -> int
     val compare : t -> t -> int
@@ -34,27 +31,26 @@ module Identifier : sig
 
   module Id = Paths_types.Identifier
 
-  module Any : IdSig with type t = Id.any and type t_pv = Id.any_pv
+  module Any : IdSig with type t = Id.any
 
   module RootModule :
-    IdSig with type t = Id.root_module and type t_pv = Id.root_module_pv
+    IdSig with type t = Id.root_module
 
   module Signature :
-    IdSig with type t = Id.signature and type t_pv = Id.signature_pv
+    IdSig with type t = Id.signature
 
   module ClassSignature :
-    IdSig with type t = Id.class_signature and type t_pv = Id.class_signature_pv
+    IdSig with type t = Id.class_signature
 
   module LabelParent :
-    IdSig with type t = Id.label_parent and type t_pv = Id.label_parent_pv
+    IdSig with type t = Id.label_parent
 
-  module Module : IdSig with type t = Id.module_ and type t_pv = Id.module_pv
+  module Module : IdSig with type t = Id.module_
 
   module FunctorParameter : sig
     include
       IdSig
         with type t = Id.functor_parameter
-         and type t_pv = Id.functor_parameter_pv
 
     val functor_arg_pos : t -> int
     (** Gets the index in which the functor argument is, in the argument list.
@@ -63,57 +59,47 @@ module Identifier : sig
   end
 
   module ModuleType :
-    IdSig with type t = Id.module_type and type t_pv = Id.module_type_pv
+    IdSig with type t = Id.module_type
 
-  module Type : IdSig with type t = Id.type_ and type t_pv = Id.type_pv
+  module Type : IdSig with type t = Id.type_
 
-  module Class : IdSig with type t = Id.class_ and type t_pv = Id.class_pv
+  module Class : IdSig with type t = Id.class_
 
   module ClassType :
-    IdSig with type t = Id.class_type and type t_pv = Id.class_type_pv
+    IdSig with type t = Id.class_type
 
   module DataType : sig
     type t = Id.datatype
-    type t_pv = Id.datatype_pv
   end
   module FieldParent : sig
     type t = Id.field_parent
-    type t_pv = Id.field_parent_pv
   end
   module UnboxedFieldParent : sig
     type t = Id.unboxed_field_parent
-    type t_pv = Id.unboxed_field_parent_pv
   end
 
   module FunctorResult : sig
     type t = Id.functor_result
-    type t_pv = Id.functor_result_pv
   end
 
   module Constructor : sig
     type t = Id.constructor
-    type t_pv = Id.constructor_pv
   end
 
   module Field : sig
     type t = Id.field
-    type t_pv = Id.field_pv
   end
 
   module UnboxedField : sig
     type t = Id.unboxed_field
-    type t_pv = Id.unboxed_field_pv
   end
 
   module Extension : sig
     type t = Id.extension
-    type t_pv = Id.extension_pv
   end
 
   module ExtensionDecl : sig
     type t = Paths_types.Identifier.extension_decl
-
-    type t_pv = Paths_types.Identifier.extension_decl_pv
 
     val equal : t -> t -> bool
 
@@ -124,106 +110,91 @@ module Identifier : sig
 
   module Exception : sig
     type t = Id.exception_
-    type t_pv = Id.exception_pv
   end
 
   module Value : sig
     type t = Id.value
-    type t_pv = Id.value_pv
   end
 
   module Method : sig
     type t = Id.method_
-    type t_pv = Id.method_pv
   end
 
   module InstanceVariable : sig
     type t = Id.instance_variable
-    type t_pv = Id.instance_variable_pv
   end
-  module Label : IdSig with type t = Id.label and type t_pv = Id.label_pv
+  module Label : IdSig with type t = Id.label
 
   module Page : sig
     type t = Id.page
-    type t_pv = Id.page_pv
   end
 
   module LeafPage : sig
     type t = Id.leaf_page
-    type t_pv = Id.leaf_page_pv
   end
 
   module ContainerPage : sig
     type t = Id.container_page
-    type t_pv = Id.container_page_pv
   end
 
   module NonSrc : sig
     type t = Id.non_src
-    type t_pv = Id.non_src_pv
     val hash : t -> int
-    val equal : ([< t_pv ] id as 'a) -> 'a -> bool
+    val equal : ([< t ] as 'a) -> 'a -> bool
   end
 
   module SourcePage : sig
     type t = Id.source_page
-    type t_pv = Id.source_page_pv
   end
 
   module SourceLocation : sig
     type t = Id.source_location
-    type t_pv = Id.source_location_pv
   end
 
   module AssetFile : sig
     type t = Id.asset_file
-    type t_pv = Id.asset_file_pv
   end
 
   module OdocId : sig
     type t = Id.odoc_id
-    type t_pv = Id.odoc_id_pv
   end
 
   module Path : sig
     module Module :
-      IdSig with type t = Id.path_module and type t_pv = Id.path_module_pv
+      IdSig with type t = Id.path_module
 
     module ModuleType :
-      IdSig with type t = Id.path_module_type and type t_pv = Id.module_type_pv
+      IdSig with type t = Id.path_module_type
 
     module Type :
-      IdSig with type t = Id.path_type and type t_pv = Id.path_type_pv
+      IdSig with type t = Id.path_type
 
-    module Value : IdSig with type t = Id.path_value and type t_pv = Id.value_pv
+    module Value : IdSig with type t = Id.path_value
 
     module ClassType :
       IdSig
         with type t = Id.path_class_type
-         and type t_pv = Id.path_class_type_pv
 
     type t = Id.path_any
   end
 
   type t = Id.any
 
-  type t_pv = Id.any_pv
-
   val hash : t -> int
 
-  val name : [< t_pv ] id -> string
+  val name : [< t ] -> string
 
-  val fullname : [< t_pv ] id -> string list
+  val fullname : [< t ] -> string list
   (** The fullname of value [x] in module [M] is [M.x], whereas the regular name
       is [x]. *)
 
-  val is_hidden : [< t_pv ] id -> bool
+  val is_hidden : [< t ] -> bool
 
   val compare : t -> t -> int
 
-  val equal : ([< t_pv ] id as 'a) -> 'a -> bool
+  val equal : ([< t ] as 'a) -> 'a -> bool
 
-  val label_parent : [< NonSrc.t_pv ] id -> LabelParent.t
+  val label_parent : [< NonSrc.t ] -> LabelParent.t
 
   module Maps : sig
     module Any : Map.S with type key = Any.t
@@ -262,11 +233,11 @@ module Identifier : sig
 
     val page :
       ContainerPage.t option * PageName.t ->
-      [> `Page of ContainerPage.t option * PageName.t ] id
+      [> `Page of ContainerPage.t option * PageName.t ]
 
     val leaf_page :
       ContainerPage.t option * PageName.t ->
-      [> `LeafPage of ContainerPage.t option * PageName.t ] id
+      [> `LeafPage of ContainerPage.t option * PageName.t ]
 
     val source_page : ContainerPage.t * string -> SourcePage.t
 
@@ -274,54 +245,54 @@ module Identifier : sig
 
     val root :
       ContainerPage.t option * ModuleName.t ->
-      [> `Root of ContainerPage.t option * ModuleName.t ] id
+      [> `Root of ContainerPage.t option * ModuleName.t ]
 
-    val implementation : string -> [> `Implementation of ModuleName.t ] id
+    val implementation : string -> [> `Implementation of ModuleName.t ]
 
     val module_ :
       Signature.t * ModuleName.t ->
-      [> `Module of Signature.t * ModuleName.t ] id
+      [> `Module of Signature.t * ModuleName.t ]
 
     val parameter :
       Signature.t * ModuleName.t ->
-      [> `Parameter of Signature.t * ModuleName.t ] id
+      [> `Parameter of Signature.t * ModuleName.t ]
 
-    val result : Signature.t -> [> `Result of Signature.t ] id
+    val result : Signature.t -> [> `Result of Signature.t ]
 
     val module_type :
       Signature.t * ModuleTypeName.t ->
-      [> `ModuleType of Signature.t * ModuleTypeName.t ] id
+      [> `ModuleType of Signature.t * ModuleTypeName.t ]
 
     val class_ :
-      Signature.t * TypeName.t -> [> `Class of Signature.t * TypeName.t ] id
+      Signature.t * TypeName.t -> [> `Class of Signature.t * TypeName.t ]
 
     val class_type :
-      Signature.t * TypeName.t -> [> `ClassType of Signature.t * TypeName.t ] id
+      Signature.t * TypeName.t -> [> `ClassType of Signature.t * TypeName.t ]
 
     val type_ :
-      Signature.t * TypeName.t -> [> `Type of Signature.t * TypeName.t ] id
+      Signature.t * TypeName.t -> [> `Type of Signature.t * TypeName.t ]
 
-    val core_type : string -> [> `CoreType of TypeName.t ] id
+    val core_type : string -> [> `CoreType of TypeName.t ]
 
     val constructor :
       DataType.t * ConstructorName.t ->
-      [> `Constructor of DataType.t * ConstructorName.t ] id
+      [> `Constructor of DataType.t * ConstructorName.t ]
 
     val field :
       FieldParent.t * FieldName.t ->
-      [> `Field of FieldParent.t * FieldName.t ] id
+      [> `Field of FieldParent.t * FieldName.t ]
 
     val unboxed_field :
       UnboxedFieldParent.t * UnboxedFieldName.t ->
-      [> `UnboxedField of UnboxedFieldParent.t * UnboxedFieldName.t ] id
+      [> `UnboxedField of UnboxedFieldParent.t * UnboxedFieldName.t ]
 
     val extension :
       Signature.t * ExtensionName.t ->
-      [> `Extension of Signature.t * ExtensionName.t ] id
+      [> `Extension of Signature.t * ExtensionName.t ]
 
     val extension_decl :
       Signature.t * (ExtensionName.t * ExtensionName.t) ->
-      [> `ExtensionDecl of Signature.t * ExtensionName.t * ExtensionName.t ] id
+      [> `ExtensionDecl of Signature.t * ExtensionName.t * ExtensionName.t ]
     (** [extension_decl (sg, e1, eN)] defines an extension declaration where
         [sg] is the parent, [e1] is the first constructor of the extension, and
         [eN] is the constructor the Id is created for. [e1] will be used for the
@@ -330,33 +301,33 @@ module Identifier : sig
 
     val exception_ :
       Signature.t * ExceptionName.t ->
-      [> `Exception of Signature.t * ExceptionName.t ] id
+      [> `Exception of Signature.t * ExceptionName.t ]
 
     val value :
-      Signature.t * ValueName.t -> [> `Value of Signature.t * ValueName.t ] id
+      Signature.t * ValueName.t -> [> `Value of Signature.t * ValueName.t ]
 
     val method_ :
       ClassSignature.t * MethodName.t ->
-      [> `Method of ClassSignature.t * MethodName.t ] id
+      [> `Method of ClassSignature.t * MethodName.t ]
 
     val instance_variable :
       ClassSignature.t * InstanceVariableName.t ->
-      [> `InstanceVariable of ClassSignature.t * InstanceVariableName.t ] id
+      [> `InstanceVariable of ClassSignature.t * InstanceVariableName.t ]
 
     val label :
       LabelParent.t * LabelName.t ->
-      [> `Label of LabelParent.t * LabelName.t ] id
+      [> `Label of LabelParent.t * LabelName.t ]
 
     val source_location :
       SourcePage.t * DefName.t ->
-      [> `SourceLocation of SourcePage.t * DefName.t ] id
+      [> `SourceLocation of SourcePage.t * DefName.t ]
 
     val source_location_mod :
-      SourcePage.t -> [> `SourceLocationMod of SourcePage.t ] id
+      SourcePage.t -> [> `SourceLocationMod of SourcePage.t ]
 
     val source_location_int :
       SourcePage.t * LocalName.t ->
-      [> `SourceLocationInternal of SourcePage.t * LocalName.t ] id
+      [> `SourceLocationInternal of SourcePage.t * LocalName.t ]
   end
 
   val fresh_include_parent : Signature.t -> Signature.t

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -1,290 +1,178 @@
 open Names
 (** {1 Paths} *)
 
-type 'a id = { iv : 'a }
-(** @canonical Odoc_model.Paths.Identifier.id *)
-
 module Identifier = struct
-  type container_page_pv = [ `Page of container_page option * PageName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.ContainerPage.t_pv *)
-
-  and container_page = container_page_pv id
+  type container_page = [ `Page of container_page option * PageName.t ]
   (** @canonical Odoc_model.Paths.Identifier.ContainerPage.t *)
 
-  type leaf_page_pv = [ `LeafPage of container_page option * PageName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.LeafPage.t_pv *)
-
-  and leaf_page = leaf_page_pv id
+  type leaf_page = [ `LeafPage of container_page option * PageName.t ]
   (** @canonical Odoc_model.Paths.Identifier.LeafPage.t *)
 
-  type page_pv = [ container_page_pv | leaf_page_pv ]
-  (** @canonical Odoc_model.Paths.Identifier.Page.t_pv *)
-
-  and page = page_pv id
+  type page = [ container_page | leaf_page ]
   (** @canonical Odoc_model.Paths.Identifier.Page.t *)
 
-  type source_page_pv = [ `SourcePage of container_page * string ]
+  type source_page = [ `SourcePage of container_page * string ]
   (** The second argument is the filename.
 
-      @canonical Odoc_model.Paths.Identifier.SourcePage.t_pv *)
+      @canonical Odoc_model.Paths.Identifier.SourcePage.t *)
 
-  type source_page = source_page_pv id
-  (** @canonical Odoc_model.Paths.Identifier.SourcePage.t *)
-
-  type asset_file_pv = [ `AssetFile of page * AssetName.t ]
+  type asset_file = [ `AssetFile of page * AssetName.t ]
   (** The second argument is the filename.
 
-      @canonical Odoc_model.Paths.Identifier.AssetFile.t_pv *)
+      @canonical Odoc_model.Paths.Identifier.AssetFile.t *)
 
-  type asset_file = asset_file_pv id
-  (** @canonical Odoc_model.Paths.Identifier.AssetFile.t *)
-
-  type source_location_pv =
+  type source_location =
     [ `SourceLocationMod of source_page
     | `SourceLocation of source_page * DefName.t
     | `SourceLocationInternal of source_page * LocalName.t ]
   (** @canonical Odoc_model.Paths.Identifier.SourceLocation.t *)
 
-  and source_location = source_location_pv id
-  (** @canonical Odoc_model.Paths.Identifier.SourceLocation.t_pv *)
-
-  type odoc_id_pv =
-    [ page_pv
-    | source_page_pv
-    | asset_file_pv
+  type odoc_id =
+    [ page
+    | source_page
+    | asset_file
     | `Root of container_page option * ModuleName.t
     | `Implementation of ModuleName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.OdocId.t_pv *)
-
-  and odoc_id = odoc_id_pv id
   (** @canonical Odoc_model.Paths.Identifier.OdocId.t *)
 
-  type signature_pv =
+  type signature =
     [ `Root of container_page option * ModuleName.t
     | `Module of signature * ModuleName.t
     | `Parameter of signature * ModuleName.t
     | `Result of signature
     | `ModuleType of signature * ModuleTypeName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.Signature.t_pv *)
-
-  and signature = signature_pv id
   (** @canonical Odoc_model.Paths.Identifier.Signature.t *)
 
-  type class_signature_pv =
+  type class_signature =
     [ `Class of signature * TypeName.t | `ClassType of signature * TypeName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.ClassSignature.t_pv *)
-
-  and class_signature = class_signature_pv id
   (** @canonical Odoc_model.Paths.Identifier.ClassSignature.t *)
 
-  type datatype_pv = [ `Type of signature * TypeName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.DataType.t_pv *)
-
-  and datatype = datatype_pv id
+  type datatype = [ `Type of signature * TypeName.t ]
   (** @canonical Odoc_model.Paths.Identifier.DataType.t *)
 
-  type field_parent_pv = [ signature_pv | datatype_pv ]
-  (** @canonical Odoc_model.Paths.Identifier.FieldParent.t_pv *)
+  type field_parent = [ signature | datatype ]
+  (** @canonical Odoc_model.Paths.Identifier.FieldParent.t *)
 
   (* fragment_type_parent in identifiers is for record fields parent. It’s type
      (for usual record fields) or [signature] for fields of inline records of
      extension constructor. *)
-  and field_parent = field_parent_pv id
-  (** @canonical Odoc_model.Paths.Identifier.FieldParent.t *)
-
-  type unboxed_field_parent_pv = datatype_pv
-  (** @canonical Odoc_model.Paths.Identifier.UnboxedFieldParent.t_pv *)
-
-  and unboxed_field_parent = unboxed_field_parent_pv id
+  type unboxed_field_parent = datatype
   (** @canonical Odoc_model.Paths.Identifier.UnboxedFieldParent.t *)
 
-  type label_parent_pv = [ field_parent_pv | page_pv | class_signature_pv ]
-  (** @canonical Odoc_model.Paths.Identifier.LabelParent.t_pv *)
-
-  and label_parent = label_parent_pv id
+  type label_parent = [ field_parent | page | class_signature ]
   (** @canonical Odoc_model.Paths.Identifier.LabelParent.t *)
 
-  type root_module_pv = [ `Root of container_page option * ModuleName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.RootModule.t_pv *)
-
-  and root_module = root_module_pv id
+  type root_module = [ `Root of container_page option * ModuleName.t ]
   (** @canonical Odoc_model.Paths.Identifier.RootModule.t *)
 
-  type module_pv =
-    [ root_module_pv
+  type module_ =
+    [ root_module
     | `Module of signature * ModuleName.t
     | `Parameter of signature * ModuleName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.Module.t_pv *)
-
-  and module_ = module_pv id
   (** @canonical Odoc_model.Paths.Identifier.Module.t *)
 
-  type functor_parameter_pv = [ `Parameter of signature * ModuleName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.FunctorParameter.t_pv *)
-
-  and functor_parameter = functor_parameter_pv id
+  type functor_parameter = [ `Parameter of signature * ModuleName.t ]
   (** @canonical Odoc_model.Paths.Identifier.FunctorParameter.t *)
 
-  type functor_result_pv = [ `Result of signature ]
-  (** @canonical Odoc_model.Paths.Identifier.FunctorResult.t_pv *)
-
-  and functor_result = functor_result_pv id
+  type functor_result = [ `Result of signature ]
   (** @canonical Odoc_model.Paths.Identifier.FunctorResult.t *)
 
-  type module_type_pv = [ `ModuleType of signature * ModuleTypeName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.ModuleType.t_pv *)
-
-  and module_type = module_type_pv id
+  type module_type = [ `ModuleType of signature * ModuleTypeName.t ]
   (** @canonical Odoc_model.Paths.Identifier.ModuleType.t *)
 
-  type type_pv = [ `Type of signature * TypeName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.Type.t_pv *)
-
-  and type_ = type_pv id
+  type type_ = [ `Type of signature * TypeName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Type.t *)
 
-  type constructor_pv = [ `Constructor of datatype * ConstructorName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.Constructor.t_pv *)
-
-  and constructor = constructor_pv id
+  type constructor = [ `Constructor of datatype * ConstructorName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Constructor.t *)
 
-  type field_pv = [ `Field of field_parent * FieldName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.Field.t_pv *)
-
-  and field = field_pv id
+  type field = [ `Field of field_parent * FieldName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Field.t *)
 
-  type unboxed_field_pv =
+  type unboxed_field =
     [ `UnboxedField of unboxed_field_parent * UnboxedFieldName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.UnboxedField.t_pv *)
-
-  and unboxed_field = unboxed_field_pv id
   (** @canonical Odoc_model.Paths.Identifier.UnboxedField.t *)
 
-  type extension_pv = [ `Extension of signature * ExtensionName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.Extension.t_pv *)
-
-  type extension_decl_pv =
-    [ `ExtensionDecl of signature * ExtensionName.t * ExtensionName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.ExtensionDecl.t_pv *)
-
-  and extension = extension_pv id
+  type extension = [ `Extension of signature * ExtensionName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Extension.t *)
 
-  and extension_decl = extension_decl_pv id
+  type extension_decl =
+    [ `ExtensionDecl of signature * ExtensionName.t * ExtensionName.t ]
   (** @canonical Odoc_model.Paths.Identifier.ExtensionDecl.t *)
 
-  type exception_pv = [ `Exception of signature * ExceptionName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.Exception.t_pv *)
-
-  and exception_ = exception_pv id
+  type exception_ = [ `Exception of signature * ExceptionName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Exception.t *)
 
-  type value_pv = [ `Value of signature * ValueName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.Value.t_pv *)
-
-  and value = value_pv id
+  type value = [ `Value of signature * ValueName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Value.t *)
 
-  type class_pv = [ `Class of signature * TypeName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.Class.t_pv *)
-
-  and class_ = class_pv id
+  type class_ = [ `Class of signature * TypeName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Class.t *)
 
-  type class_type_pv = [ `ClassType of signature * TypeName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.ClassType.t_pv *)
-
-  and class_type = class_type_pv id
+  type class_type = [ `ClassType of signature * TypeName.t ]
   (** @canonical Odoc_model.Paths.Identifier.ClassType.t *)
 
-  type method_pv = [ `Method of class_signature * MethodName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.Method.t_pv *)
-
-  and method_ = method_pv id
+  type method_ = [ `Method of class_signature * MethodName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Method.t *)
 
-  type instance_variable_pv =
+  type instance_variable =
     [ `InstanceVariable of class_signature * InstanceVariableName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.InstanceVariable.t_pv *)
-
-  and instance_variable = instance_variable_pv id
   (** @canonical Odoc_model.Paths.Identifier.InstanceVariable.t *)
 
-  type label_pv = [ `Label of label_parent * LabelName.t ]
-  (** @canonical Odoc_model.Paths.Identifier.Label.t_pv *)
-
-  and label = label_pv id
+  type label = [ `Label of label_parent * LabelName.t ]
   (** @canonical Odoc_model.Paths.Identifier.Label.t *)
 
-  type non_src_pv =
-    [ signature_pv
-    | class_signature_pv
-    | datatype_pv
-    | field_parent_pv
-    | unboxed_field_parent_pv
-    | label_parent_pv
-    | module_pv
-    | functor_parameter_pv
-    | functor_result_pv
-    | module_type_pv
-    | type_pv
-    | constructor_pv
-    | field_pv
-    | unboxed_field_pv
-    | extension_pv
-    | extension_decl_pv
-    | exception_pv
-    | value_pv
-    | class_pv
-    | class_type_pv
-    | method_pv
-    | instance_variable_pv
-    | label_pv
-    | page_pv ]
-  (** @canonical Odoc_model.Paths.Identifier.NonSrc.t_pv *)
-
-  and non_src = non_src_pv id
+  type non_src =
+    [ signature
+    | class_signature
+    | datatype
+    | field_parent
+    | unboxed_field_parent
+    | label_parent
+    | module_
+    | functor_parameter
+    | functor_result
+    | module_type
+    | type_
+    | constructor
+    | field
+    | unboxed_field
+    | extension
+    | extension_decl
+    | exception_
+    | value
+    | class_
+    | class_type
+    | method_
+    | instance_variable
+    | label
+    | page ]
   (** @canonical Odoc_model.Paths.Identifier.NonSrc.t *)
 
-  type any_pv =
-    [ non_src_pv | source_page_pv | source_location_pv | asset_file_pv ]
-  (** @canonical Odoc_model.Paths.Identifier.t_pv *)
-
-  and any = any_pv id
+  type any =
+    [ non_src | source_page | source_location | asset_file ]
   (** @canonical Odoc_model.Paths.Identifier.t *)
 
-  type path_module_pv = [ module_pv | functor_parameter_pv | functor_result_pv ]
-  (** @canonical Odoc_model.Paths.Identifier.Path.Module.t_pv *)
-
-  and path_module = path_module_pv id
+  type path_module = [ module_ | functor_parameter | functor_result ]
   (** @canonical Odoc_model.Paths.Identifier.Path.Module.t *)
 
   type path_module_type = module_type
   (** @canonical Odoc_model.Paths.Identifier.Path.ModuleType.t *)
 
-  type path_type_pv = [ type_pv | class_pv | class_type_pv ]
-  (** @canonical Odoc_model.Paths.Identifier.Path.Type.t_pv *)
-
-  and path_type = path_type_pv id
+  type path_type = [ type_ | class_ | class_type ]
   (** @canonical Odoc_model.Paths.Identifier.Path.Type.t *)
 
   type path_value = value
 
-  type path_class_type_pv = [ class_pv | class_type_pv ]
-  (** @canonical Odoc_model.Paths.Identifier.Path.ClassType.t_pv *)
-
-  and path_class_type = path_class_type_pv id
+  type path_class_type = [ class_ | class_type ]
   (** @canonical Odoc_model.Paths.Identifier.Path.ClassType.t *)
 
   type path_any =
-    [ path_module_pv
-    | module_type_pv
-    | path_type_pv
-    | path_class_type_pv
-    | value_pv ]
-    id
+    [ path_module
+    | module_type
+    | path_type
+    | path_class_type
+    | value ]
   (** @canonical Odoc_model.Paths.Identifier.Path.t *)
 
   type fragment_module = path_module
@@ -298,13 +186,13 @@ module Identifier = struct
   type reference_type = path_type
 
   type reference_constructor =
-    [ constructor_pv | extension_pv | exception_pv ] id
+    [ constructor | extension | exception_ ]
 
   type reference_field = field
 
   type reference_unboxed_field = unboxed_field
 
-  type reference_extension = [ extension_pv | exception_pv ] id
+  type reference_extension = [ extension | exception_ ]
 
   type reference_extension_decl = extension_decl
 
@@ -314,7 +202,7 @@ module Identifier = struct
 
   type reference_class = class_
 
-  type reference_class_type = [ class_pv | class_type_pv ] id
+  type reference_class_type = [ class_ | class_type ]
 
   type reference_method = method_
 

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -1,7 +1,7 @@
 open Names
 (** {1 Paths} *)
 
-type 'a id = { iv : 'a; ihash : int; ikey : string }
+type 'a id = { iv : 'a }
 (** @canonical Odoc_model.Paths.Identifier.id *)
 
 module Identifier = struct

--- a/src/model/paths_types.ml
+++ b/src/model/paths_types.ml
@@ -149,8 +149,7 @@ module Identifier = struct
     | page ]
   (** @canonical Odoc_model.Paths.Identifier.NonSrc.t *)
 
-  type any =
-    [ non_src | source_page | source_location | asset_file ]
+  type any = [ non_src | source_page | source_location | asset_file ]
   (** @canonical Odoc_model.Paths.Identifier.t *)
 
   type path_module = [ module_ | functor_parameter | functor_result ]
@@ -168,11 +167,7 @@ module Identifier = struct
   (** @canonical Odoc_model.Paths.Identifier.Path.ClassType.t *)
 
   type path_any =
-    [ path_module
-    | module_type
-    | path_type
-    | path_class_type
-    | value ]
+    [ path_module | module_type | path_type | path_class_type | value ]
   (** @canonical Odoc_model.Paths.Identifier.Path.t *)
 
   type fragment_module = path_module
@@ -185,8 +180,7 @@ module Identifier = struct
 
   type reference_type = path_type
 
-  type reference_constructor =
-    [ constructor | extension | exception_ ]
+  type reference_constructor = [ constructor | extension | exception_ ]
 
   type reference_field = field
 

--- a/src/model/root.ml
+++ b/src/model/root.ml
@@ -78,7 +78,7 @@ let to_string t =
         let rec loop_pp fmt parent =
           match parent.Paths.Identifier.iv with
           | `SourceDir (p, name) -> Format.fprintf fmt "%a::%s" loop_pp p name
-          | `Page _ as iv -> Format.fprintf fmt "%a" pp { parent with iv }
+          | `Page _ as iv -> Format.fprintf fmt "%a" pp { Paths.Identifier.iv }
         in
         Format.fprintf fmt "%a::%s" loop_pp parent name
     | `LeafPage (parent, name) | `Page (parent, name) -> (

--- a/src/model/root.ml
+++ b/src/model/root.ml
@@ -73,12 +73,12 @@ let hash : t -> int = Hashtbl.hash
 
 let to_string t =
   let rec pp fmt (id : Paths.Identifier.OdocId.t) =
-    match id.iv with
+    match id with
     | `SourcePage (parent, name) ->
         let rec loop_pp fmt parent =
-          match parent.Paths.Identifier.iv with
+          match parent with
           | `SourceDir (p, name) -> Format.fprintf fmt "%a::%s" loop_pp p name
-          | `Page _ as iv -> Format.fprintf fmt "%a" pp { Paths.Identifier.iv }
+          | `Page _ as iv -> Format.fprintf fmt "%a" pp iv
         in
         Format.fprintf fmt "%a::%s" loop_pp parent name
     | `LeafPage (parent, name) | `Page (parent, name) -> (

--- a/src/model/semantics.ml
+++ b/src/model/semantics.ml
@@ -433,7 +433,7 @@ let section_heading :
   mk_heading level'
 
 let validate_first_page_heading status ast_element =
-  match status.parent_of_sections.iv with
+  match status.parent_of_sections with
   | `Page (_, name) | `LeafPage (_, name) -> (
       match ast_element with
       | { Location.value = `Heading (_, _, _); _ } -> ()
@@ -483,7 +483,7 @@ let top_level_block_elements status ast_elements =
   in
   let top_heading_level =
     (* Non-page documents have a generated title. *)
-    match status.parent_of_sections.iv with
+    match status.parent_of_sections with
     | `Page _ | `LeafPage _ -> None
     | _parent_with_generated_title -> Some 0
   in

--- a/src/model_desc/paths_desc.ml
+++ b/src/model_desc/paths_desc.ml
@@ -69,7 +69,7 @@ module General_paths = struct
   let rec identifier : Paths.Identifier.t t =
     Variant
       (fun x ->
-        match x.iv with
+        match x with
         | `Page (parent, name) ->
             C
               ( "`Page",
@@ -533,7 +533,7 @@ let root = Root.t
 let modulename = Names.modulename
 
 (* Indirection seems to be required to make the type open. *)
-let identifier : [< Paths.Identifier.t_pv ] Paths.Identifier.id Type_desc.t =
+let identifier : [< Paths.Identifier.t ] Type_desc.t =
   Indirect ((fun n -> (n :> Paths.Identifier.t)), General_paths.identifier)
 
 let resolved_path : [< Paths.Path.Resolved.t ] Type_desc.t =

--- a/src/model_desc/paths_desc.mli
+++ b/src/model_desc/paths_desc.mli
@@ -4,7 +4,7 @@ val root : Odoc_model.Root.t Type_desc.t
 
 val modulename : Odoc_model.Names.ModuleName.t Type_desc.t
 
-val identifier : [< Identifier.t_pv ] Odoc_model.Paths.Identifier.id Type_desc.t
+val identifier : [< Identifier.t ] Type_desc.t
 
 val resolved_path : [< Path.Resolved.t ] Type_desc.t
 

--- a/src/occurrences/table.ml
+++ b/src/occurrences/table.ml
@@ -31,7 +31,7 @@ let add ?(quantity = 1) tbl id =
       let htbl = add (parent :> key) in
       incr htbl id
     in
-    match id.iv with
+    match id with
     | `InstanceVariable (parent, _) -> do_ parent
     | `Parameter (parent, _) -> do_ parent
     | `Module (parent, _) -> do_ parent
@@ -62,7 +62,7 @@ let rec get t id =
     | None -> None
     | Some { sub; _ } -> ( try Some (H.find sub id) with Not_found -> None)
   in
-  match id.iv with
+  match id with
   | `InstanceVariable (parent, _) -> do_ parent
   | `Parameter (parent, _) -> do_ parent
   | `Module (parent, _) -> do_ parent
@@ -99,7 +99,7 @@ module Strip = struct
   open Odoc_model.Paths.Identifier
   let rec strip_sig_path : Signature.t -> Signature.t =
    fun x ->
-    match x.iv with
+    match x with
     | `Root (_, name) -> Mk.root (None, name)
     | `Module (p, name) -> Mk.module_ (strip_sig_path p, name)
     | `Parameter (p, name) -> Mk.parameter (strip_sig_path p, name)
@@ -108,65 +108,61 @@ module Strip = struct
 
   and strip_class_sig_path : ClassSignature.t -> ClassSignature.t =
    fun x ->
-    match x.iv with
+    match x with
     | `Class (p, name) -> Mk.class_ (strip_sig_path p, name)
     | `ClassType (p, name) -> Mk.class_type (strip_sig_path p, name)
 
   and strip_datatype_path : DataType.t -> DataType.t =
    fun x ->
-    match x.iv with `Type (p, name) -> Mk.type_ (strip_sig_path p, name)
+    match x with `Type (p, name) -> Mk.type_ (strip_sig_path p, name)
 
   and strip_field_parent_path : FieldParent.t -> FieldParent.t =
    fun x ->
     match x with
-    | { iv = #Signature.t_pv; _ } as v -> (strip_sig_path v :> FieldParent.t)
-    | { iv = #DataType.t_pv; _ } as v ->
+    | #Signature.t as v -> (strip_sig_path v :> FieldParent.t)
+    | #DataType.t as v ->
         (strip_datatype_path v :> FieldParent.t)
 
   and strip_unboxed_field_parent_path :
       UnboxedFieldParent.t -> UnboxedFieldParent.t =
    fun x ->
     match x with
-    | { iv = #DataType.t_pv; _ } as v ->
+    | #DataType.t as v ->
         (strip_datatype_path v :> UnboxedFieldParent.t)
 
   and strip_label_parent_path : LabelParent.t -> LabelParent.t =
    fun x ->
     match x with
-    | { iv = #Signature.t_pv; _ } as v -> (strip_sig_path v :> LabelParent.t)
-    | { iv = #DataType.t_pv; _ } as v ->
+    | #Signature.t as v -> (strip_sig_path v :> LabelParent.t)
+    | #DataType.t as v ->
         (strip_datatype_path v :> LabelParent.t)
-    | { iv = #ClassSignature.t_pv; _ } as v ->
+    | #ClassSignature.t as v ->
         (strip_class_sig_path v :> LabelParent.t)
-    | { iv = `Page _ | `LeafPage _; _ } -> x
+    | `Page _ | `LeafPage _ -> x
 
   and strip : t -> t =
    fun x ->
     match x with
-    | { iv = #Signature.t_pv; _ } as v -> (strip_sig_path v :> t)
-    | { iv = #ClassSignature.t_pv; _ } as v -> (strip_class_sig_path v :> t)
-    | { iv = #DataType.t_pv; _ } as v -> (strip_datatype_path v :> t)
-    | { iv = `InstanceVariable (p, name); _ } ->
+    | #Signature.t as v -> (strip_sig_path v :> t)
+    | #ClassSignature.t as v -> (strip_class_sig_path v :> t)
+    | #DataType.t as v -> (strip_datatype_path v :> t)
+    | `InstanceVariable (p, name) ->
         Mk.instance_variable (strip_class_sig_path p, name)
-    | { iv = `Method (p, name); _ } -> Mk.method_ (strip_class_sig_path p, name)
-    | { iv = `Field (p, name); _ } -> Mk.field (strip_field_parent_path p, name)
-    | { iv = `UnboxedField (p, name); _ } ->
+    | `Method (p, name) -> Mk.method_ (strip_class_sig_path p, name)
+    | `Field (p, name) -> Mk.field (strip_field_parent_path p, name)
+    | `UnboxedField (p, name) ->
         Mk.unboxed_field (strip_unboxed_field_parent_path p, name)
-    | { iv = `Label (p, name); _ } -> Mk.label (strip_label_parent_path p, name)
-    | { iv = `Exception (p, name); _ } -> Mk.exception_ (strip_sig_path p, name)
-    | { iv = `Extension (p, name); _ } -> Mk.extension (strip_sig_path p, name)
-    | { iv = `Value (p, name); _ } -> Mk.value (strip_sig_path p, name)
-    | { iv = `ExtensionDecl (p, name, args); _ } ->
+    | `Label (p, name) -> Mk.label (strip_label_parent_path p, name)
+    | `Exception (p, name) -> Mk.exception_ (strip_sig_path p, name)
+    | `Extension (p, name) -> Mk.extension (strip_sig_path p, name)
+    | `Value (p, name) -> Mk.value (strip_sig_path p, name)
+    | `ExtensionDecl (p, name, args) ->
         Mk.extension_decl (strip_sig_path p, (name, args))
-    | { iv = `Constructor (p, name); _ } ->
+    | `Constructor (p, name) ->
         Mk.constructor (strip_datatype_path p, name)
-    | {
-     iv =
-       ( `AssetFile (_, _)
+    | ( `AssetFile (_, _)
        | `SourceLocationMod _ | `SourceLocation _ | `Page _ | `LeafPage _
-       | `SourcePage _ | `SourceLocationInternal _ );
-     _;
-    } ->
+       | `SourcePage _ | `SourceLocationInternal _ ) ->
         x
 
   let rec strip_table tbl =

--- a/src/occurrences/table.ml
+++ b/src/occurrences/table.ml
@@ -113,31 +113,26 @@ module Strip = struct
     | `ClassType (p, name) -> Mk.class_type (strip_sig_path p, name)
 
   and strip_datatype_path : DataType.t -> DataType.t =
-   fun x ->
-    match x with `Type (p, name) -> Mk.type_ (strip_sig_path p, name)
+   fun x -> match x with `Type (p, name) -> Mk.type_ (strip_sig_path p, name)
 
   and strip_field_parent_path : FieldParent.t -> FieldParent.t =
    fun x ->
     match x with
     | #Signature.t as v -> (strip_sig_path v :> FieldParent.t)
-    | #DataType.t as v ->
-        (strip_datatype_path v :> FieldParent.t)
+    | #DataType.t as v -> (strip_datatype_path v :> FieldParent.t)
 
   and strip_unboxed_field_parent_path :
       UnboxedFieldParent.t -> UnboxedFieldParent.t =
    fun x ->
     match x with
-    | #DataType.t as v ->
-        (strip_datatype_path v :> UnboxedFieldParent.t)
+    | #DataType.t as v -> (strip_datatype_path v :> UnboxedFieldParent.t)
 
   and strip_label_parent_path : LabelParent.t -> LabelParent.t =
    fun x ->
     match x with
     | #Signature.t as v -> (strip_sig_path v :> LabelParent.t)
-    | #DataType.t as v ->
-        (strip_datatype_path v :> LabelParent.t)
-    | #ClassSignature.t as v ->
-        (strip_class_sig_path v :> LabelParent.t)
+    | #DataType.t as v -> (strip_datatype_path v :> LabelParent.t)
+    | #ClassSignature.t as v -> (strip_class_sig_path v :> LabelParent.t)
     | `Page _ | `LeafPage _ -> x
 
   and strip : t -> t =
@@ -158,11 +153,10 @@ module Strip = struct
     | `Value (p, name) -> Mk.value (strip_sig_path p, name)
     | `ExtensionDecl (p, name, args) ->
         Mk.extension_decl (strip_sig_path p, (name, args))
-    | `Constructor (p, name) ->
-        Mk.constructor (strip_datatype_path p, name)
-    | ( `AssetFile (_, _)
-       | `SourceLocationMod _ | `SourceLocation _ | `Page _ | `LeafPage _
-       | `SourcePage _ | `SourceLocationInternal _ ) ->
+    | `Constructor (p, name) -> Mk.constructor (strip_datatype_path p, name)
+    | `AssetFile (_, _)
+    | `SourceLocationMod _ | `SourceLocation _ | `Page _ | `LeafPage _
+    | `SourcePage _ | `SourceLocationInternal _ ->
         x
 
   let rec strip_table tbl =

--- a/src/odoc/bin/main.ml
+++ b/src/odoc/bin/main.ml
@@ -1493,7 +1493,7 @@ module Depends = struct
 
   module Link = struct
     let rec fmt_page pp page =
-      match page.Odoc_model.Paths.Identifier.iv with
+      match page with
       | `Page (parent_opt, name) ->
           Format.fprintf pp "%a%a" fmt_parent_opt parent_opt
             Odoc_model.Names.PageName.fmt name
@@ -1510,7 +1510,7 @@ module Depends = struct
       Depends.for_rendering_step (Fs.Directory.of_string input_file)
       >>= fun depends ->
       List.iter depends ~f:(fun (root : Odoc_model.Root.t) ->
-          match root.id.iv with
+          match root.id with
           | `Root (Some p, _) ->
               Format.printf "%a %s %s\n" fmt_page p
                 (Odoc_model.Root.Odoc_file.name root.file)

--- a/src/odoc/compile.ml
+++ b/src/odoc/compile.ml
@@ -45,7 +45,7 @@ let rec path_of_id output_dir id =
   match id with
   | None -> Fpath.v output_dir
   | Some id -> (
-      match (id : Paths.Identifier.ContainerPage.t).iv with
+      match (id : Paths.Identifier.ContainerPage.t) with
       | `Page (parent, p) ->
           let d = path_of_id output_dir parent in
           Fpath.(d / PageName.to_string p))
@@ -88,8 +88,8 @@ let resolve_parent_page resolver f =
     | Module_child _ -> Error (`Msg "Expecting page as parent")
   in
   let extract_parent = function
-    | { Paths.Identifier.iv = `Page _; _ } as container -> Ok container
-    | { Paths.Identifier.iv = `LeafPage _; _ } ->
+    | `Page _ as container -> Ok container
+    | `LeafPage _ ->
         Error (`Msg "Specified parent is not a parent of this file")
   in
   parse_parent_child_reference f >>= fun r ->
@@ -208,8 +208,8 @@ let name_of_output ~prefix output =
 let page_name_of_output output = name_of_output ~prefix:"page-" output
 
 let is_index_page = function
-  | { Paths.Identifier.iv = `Page _; _ } -> false
-  | { iv = `LeafPage (_, p); _ } ->
+  | `Page _ -> false
+  | `LeafPage (_, p) ->
       Astring.String.equal (Names.PageName.to_string p) "index"
 
 let has_children_order { Frontmatter.children_order; _ } =

--- a/src/search/json_index/json_search.ml
+++ b/src/search/json_index/json_search.ml
@@ -40,7 +40,7 @@ let rec of_id x =
   let ret kind name =
     `Object [ ("kind", `String kind); ("name", `String name) ]
   in
-  match x.iv with
+  match x with
   | `Root (_, name) -> [ ret "Root" (ModuleName.to_string name) ]
   | `Page (_, name) -> [ ret "Page" (PageName.to_string name) ]
   | `AssetFile (_, name) -> [ ret "Asset" (AssetName.to_string name) ]
@@ -95,7 +95,7 @@ let rec prefix_name_kind_of_id (n : Odoc_model.Paths.Identifier.t) =
     in
     if prefix = "" then pname else prefix ^ "." ^ pname
   in
-  match n.iv with
+  match n with
   | `Root (_, name) -> ("", ModuleName.to_string name, "module")
   | `Page (_, name) -> ("", PageName.to_string name, "page")
   | `AssetFile (_, name) -> ("", AssetName.to_string name, "asset")

--- a/src/xref2/compile.ml
+++ b/src/xref2/compile.ml
@@ -757,7 +757,7 @@ and type_decl : Env.t -> TypeDecl.t -> TypeDecl.t =
  fun env t ->
   let open TypeDecl in
   let container =
-    match t.id.iv with `Type (parent, _) -> (parent :> Id.LabelParent.t)
+    match t.id with `Type (parent, _) -> (parent :> Id.LabelParent.t)
   in
   let equation = type_decl_equation env container t.equation in
   let representation =

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -1997,8 +1997,7 @@ module Of_Lang = struct
 
   let find_any_module i ident_map =
     match i with
-    | `Root _ | `Module _ as id ->
-        Maps.Module.find id ident_map.modules
+    | (`Root _ | `Module _) as id -> Maps.Module.find id ident_map.modules
     | #Paths.Identifier.FunctorParameter.t as id ->
         Maps.FunctorParameter.find id ident_map.functor_parameters
     | _ -> raise Not_found

--- a/src/xref2/component.ml
+++ b/src/xref2/component.ml
@@ -681,7 +681,7 @@ module Fmt = struct
     if c.short_paths then Ident.short_fmt ppf i else Ident.fmt ppf i
 
   let rec model_identifier c ppf (p : id) =
-    match p.iv with
+    match p with
     | `Root (_, unit_name) ->
         wrap c "root" (fun _ -> ModuleName.fmt) ppf unit_name
     | `Module (parent, name) ->
@@ -1997,12 +1997,9 @@ module Of_Lang = struct
 
   let find_any_module i ident_map =
     match i with
-    | { Odoc_model.Paths.Identifier.iv = `Root _ | `Module _; _ } as id ->
+    | `Root _ | `Module _ as id ->
         Maps.Module.find id ident_map.modules
-    | {
-        Odoc_model.Paths.Identifier.iv = #Paths.Identifier.FunctorParameter.t_pv;
-        _;
-      } as id ->
+    | #Paths.Identifier.FunctorParameter.t as id ->
         Maps.FunctorParameter.find id ident_map.functor_parameters
     | _ -> raise Not_found
 

--- a/src/xref2/cpath.ml
+++ b/src/xref2/cpath.ml
@@ -225,7 +225,7 @@ and is_resolved_parent_hidden :
 
 and is_module_type_hidden : module_type -> bool = function
   | `Resolved r -> is_resolved_module_type_hidden r
-  | `Identifier ({ iv = `ModuleType (_, t); _ }, b) ->
+  | `Identifier (`ModuleType (_, t), b) ->
       b || ModuleTypeName.is_hidden t
   | `Local (_, b) -> b
   | `Substituted p -> is_module_type_hidden p
@@ -247,9 +247,9 @@ and is_resolved_module_type_hidden : Resolved.module_type -> bool = function
 
 and is_type_hidden : type_ -> bool = function
   | `Resolved r -> is_resolved_type_hidden r
-  | `Identifier ({ iv = `Type (_, t); _ }, b) -> b || TypeName.is_hidden t
-  | `Identifier ({ iv = `ClassType (_, t); _ }, b) -> b || TypeName.is_hidden t
-  | `Identifier ({ iv = `Class (_, t); _ }, b) -> b || TypeName.is_hidden t
+  | `Identifier (`Type (_, t), b) -> b || TypeName.is_hidden t
+  | `Identifier (`ClassType (_, t), b) -> b || TypeName.is_hidden t
+  | `Identifier (`Class (_, t), b) -> b || TypeName.is_hidden t
   | `Local (_, b) -> b
   | `Substituted p -> is_type_hidden (p :> type_)
   | `DotT (p, _) -> is_module_hidden p
@@ -295,7 +295,7 @@ let rec resolved_module_of_resolved_module_reference :
 
 and resolved_module_of_resolved_signature_reference :
     Reference.Resolved.Signature.t -> Resolved.module_ = function
-  | `Identifier ({ iv = #Identifier.Module.t_pv; _ } as i) ->
+  | `Identifier (#Identifier.Module.t as i) ->
       `Gpath (`Identifier i)
   | (`Alias _ | `Module _ | `Hidden _) as r' ->
       resolved_module_of_resolved_module_reference r'
@@ -308,13 +308,13 @@ and module_of_module_reference : Reference.Module.t -> module_ = function
   | `Resolved r -> `Resolved (resolved_module_of_resolved_module_reference r)
   | `Root (_, _) -> failwith "unhandled"
   | `Dot
-      ( (( `Resolved (`Identifier { iv = #Identifier.Module.t_pv; _ })
+      ( (( `Resolved (`Identifier #Identifier.Module.t)
          | `Dot (_, _)
          | `Module (_, _) ) as parent),
         name ) ->
       `Dot (module_of_module_reference parent, ModuleName.make_std name)
   | `Module
-      ( (( `Resolved (`Identifier { iv = #Identifier.Module.t_pv; _ })
+      ( (( `Resolved (`Identifier #Identifier.Module.t)
          | `Dot (_, _)
          | `Module (_, _) ) as parent),
         name ) ->
@@ -325,7 +325,7 @@ let rec unresolve_resolved_module_path : Resolved.module_ -> module_ = function
   | `Hidden (`Gpath (`Identifier x)) -> `Identifier (x, true)
   | `Gpath (`Identifier x) ->
       let hidden =
-        match x.iv with
+        match x with
         | `Module (_, n) -> Odoc_model.Names.ModuleName.is_hidden n
         | _ -> false
       in
@@ -431,7 +431,7 @@ let rec original_path_cpath : module_ -> module_ option = function
 and original_path_module_identifier :
     Odoc_model.Paths.Identifier.Path.Module.t -> Resolved.module_ option =
  fun id ->
-  match id.iv with
+  match id with
   | `Module (sg, name) -> (
       match original_path_parent_identifier sg with
       | Some sg' -> Some (`Module (sg', name))
@@ -444,11 +444,11 @@ and original_path_parent_identifier :
     Odoc_model.Paths.Identifier.Signature.t -> Resolved.parent option =
  fun id ->
   match id with
-  | { iv = `Module _ | `Root _ | `Parameter _ | `Result _; _ } as mid -> (
+  | `Module _ | `Root _ | `Parameter _ | `Result _ as mid -> (
       match original_path_module_identifier mid with
       | Some m -> Some (`Module m)
       | None -> None)
-  | { iv = `ModuleType _; _ } as mtid -> (
+  | `ModuleType _ as mtid -> (
       match original_path_module_type_identifier mtid with
       | Some m -> Some (`ModuleType m)
       | None -> None)
@@ -456,7 +456,7 @@ and original_path_parent_identifier :
 and original_path_module_type_identifier :
     Odoc_model.Paths.Identifier.ModuleType.t -> Resolved.module_type option =
  fun id ->
-  match id.iv with
+  match id with
   | `ModuleType (sg, name) -> (
       match original_path_parent_identifier sg with
       | Some sg' -> Some (`ModuleType (sg', name))

--- a/src/xref2/cpath.ml
+++ b/src/xref2/cpath.ml
@@ -225,8 +225,7 @@ and is_resolved_parent_hidden :
 
 and is_module_type_hidden : module_type -> bool = function
   | `Resolved r -> is_resolved_module_type_hidden r
-  | `Identifier (`ModuleType (_, t), b) ->
-      b || ModuleTypeName.is_hidden t
+  | `Identifier (`ModuleType (_, t), b) -> b || ModuleTypeName.is_hidden t
   | `Local (_, b) -> b
   | `Substituted p -> is_module_type_hidden p
   | `DotMT (p, _) -> is_module_hidden p
@@ -295,8 +294,7 @@ let rec resolved_module_of_resolved_module_reference :
 
 and resolved_module_of_resolved_signature_reference :
     Reference.Resolved.Signature.t -> Resolved.module_ = function
-  | `Identifier (#Identifier.Module.t as i) ->
-      `Gpath (`Identifier i)
+  | `Identifier (#Identifier.Module.t as i) -> `Gpath (`Identifier i)
   | (`Alias _ | `Module _ | `Hidden _) as r' ->
       resolved_module_of_resolved_module_reference r'
   | `ModuleType (_, n) ->

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -132,13 +132,13 @@ module ElementsById : sig
   val empty : t
 
   val add :
-    [< Identifier.t_pv ] Paths.Identifier.id ->
+    [< Identifier.t ] ->
     [< Component.Element.any ] ->
     t ->
     t
 
   val find_by_id :
-    [< Identifier.t_pv ] Paths.Identifier.id ->
+    [< Identifier.t ] ->
     t ->
     Component.Element.any option
 end = struct
@@ -440,7 +440,7 @@ let lookup_root_module name env =
         | Ok Forward_reference -> Some Forward
         | Error `Not_found -> None
         | Ok (Found u) ->
-            let ({ Odoc_model.Paths.Identifier.iv = `Root _; _ } as id) =
+            let (`Root _ as id) =
               u.id
             in
             let m = module_of_unit u in
@@ -551,7 +551,7 @@ let lookup_by_id (scope : 'a scope) id env : 'a option =
   | None -> (
       (* Format.eprintf "Can't find %a\n%!" Component.Fmt.model_identifier (id :> Identifier.t); *)
       match (id :> Identifier.t) with
-      | { iv = `Root (_, name); _ } ->
+      | `Root (_, name) ->
           scope.root (ModuleName.to_string name) env
       | _ -> None)
 

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -131,16 +131,9 @@ module ElementsById : sig
 
   val empty : t
 
-  val add :
-    [< Identifier.t ] ->
-    [< Component.Element.any ] ->
-    t ->
-    t
+  val add : [< Identifier.t ] -> [< Component.Element.any ] -> t -> t
 
-  val find_by_id :
-    [< Identifier.t ] ->
-    t ->
-    Component.Element.any option
+  val find_by_id : [< Identifier.t ] -> t -> Component.Element.any option
 end = struct
   module IdMap = Identifier.Maps.Any
 
@@ -440,9 +433,7 @@ let lookup_root_module name env =
         | Ok Forward_reference -> Some Forward
         | Error `Not_found -> None
         | Ok (Found u) ->
-            let (`Root _ as id) =
-              u.id
-            in
+            let (`Root _ as id) = u.id in
             let m = module_of_unit u in
             Some (Resolved (u.root, id, m)))
   in
@@ -551,8 +542,7 @@ let lookup_by_id (scope : 'a scope) id env : 'a option =
   | None -> (
       (* Format.eprintf "Can't find %a\n%!" Component.Fmt.model_identifier (id :> Identifier.t); *)
       match (id :> Identifier.t) with
-      | `Root (_, name) ->
-          scope.root (ModuleName.to_string name) env
+      | `Root (_, name) -> scope.root (ModuleName.to_string name) env
       | _ -> None)
 
 let lookup_root_module_fallback name t =

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -124,7 +124,7 @@ val lookup_by_name : 'a scope -> string -> t -> 'a maybe_ambiguous
     name. *)
 
 val lookup_by_id :
-  'a scope -> [< Identifier.t_pv ] Paths.Identifier.id -> t -> 'a option
+  'a scope -> [< Identifier.t ] -> t -> 'a option
 (** Like [lookup_by_name] but use an identifier as key. *)
 
 val s_any : Component.Element.any scope

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -123,8 +123,7 @@ val lookup_by_name : 'a scope -> string -> t -> 'a maybe_ambiguous
     [Error (`Ambiguous _)] when two or more elements match the given scope and
     name. *)
 
-val lookup_by_id :
-  'a scope -> [< Identifier.t ] -> t -> 'a option
+val lookup_by_id : 'a scope -> [< Identifier.t ] -> t -> 'a option
 (** Like [lookup_by_name] but use an identifier as key. *)
 
 val s_any : Component.Element.any scope

--- a/src/xref2/errors.ml
+++ b/src/xref2/errors.ml
@@ -263,7 +263,7 @@ let rec kind_of_error : Tools_error.any -> kind option = function
       match kind_of_module_type_cpath cp with
       | None -> kind_of_error (e :> Tools_error.any)
       | x -> x)
-  | `Lookup_failure { iv = `Root (_, name); _ } ->
+  | `Lookup_failure `Root (_, name) ->
       Some (`Root (ModuleName.to_string name))
   | `Lookup_failure_root name -> Some (`Root (ModuleName.to_string name))
   | `Parent (`Parent_sig e) -> kind_of_error (e :> Tools_error.any)
@@ -286,7 +286,7 @@ let kind_of_error ~what = function
   | None -> (
       match what with
       | `Include (Component.Include.Alias cp) -> kind_of_module_cpath cp
-      | `Module { Odoc_model.Paths.Identifier.iv = `Root (_, name); _ } ->
+      | `Module `Root (_, name) ->
           Some (`Root (ModuleName.to_string name))
       | _ -> None)
 

--- a/src/xref2/errors.ml
+++ b/src/xref2/errors.ml
@@ -263,7 +263,7 @@ let rec kind_of_error : Tools_error.any -> kind option = function
       match kind_of_module_type_cpath cp with
       | None -> kind_of_error (e :> Tools_error.any)
       | x -> x)
-  | `Lookup_failure `Root (_, name) ->
+  | `Lookup_failure (`Root (_, name)) ->
       Some (`Root (ModuleName.to_string name))
   | `Lookup_failure_root name -> Some (`Root (ModuleName.to_string name))
   | `Parent (`Parent_sig e) -> kind_of_error (e :> Tools_error.any)
@@ -286,8 +286,7 @@ let kind_of_error ~what = function
   | None -> (
       match what with
       | `Include (Component.Include.Alias cp) -> kind_of_module_cpath cp
-      | `Module `Root (_, name) ->
-          Some (`Root (ModuleName.to_string name))
+      | `Module (`Root (_, name)) -> Some (`Root (ModuleName.to_string name))
       | _ -> None)
 
 open Paths

--- a/src/xref2/ident.ml
+++ b/src/xref2/ident.ml
@@ -72,49 +72,49 @@ module Of_Identifier = struct
   let type_ : Type.t -> type_ =
    fun t ->
     let i = fresh_int () in
-    match t.iv with `Type (_, n) -> `LType (n, i)
+    match t with `Type (_, n) -> `LType (n, i)
 
   let module_ : Module.t -> module_ = function
-    | { iv = `Module (_, n) | `Root (_, n); _ } ->
+    | `Module (_, n) | `Root (_, n) ->
         let i = fresh_int () in
         `LModule (n, i)
-    | { iv = `Parameter (_, n); _ } ->
+    | `Parameter (_, n) ->
         let i = fresh_int () in
         `LModule (n, i)
 
   let functor_parameter : FunctorParameter.t -> module_ =
-   fun { iv = `Parameter (_, n); _ } -> `LModule (n, fresh_int ())
+   fun (`Parameter (_, n)) -> `LModule (n, fresh_int ())
 
   let module_type : ModuleType.t -> module_type =
    fun m ->
     let i = fresh_int () in
-    match m.iv with `ModuleType (_, n) -> `LModuleType (n, i)
+    match m with `ModuleType (_, n) -> `LModuleType (n, i)
 
   let extension : Extension.t -> extension =
-   fun e -> match e.iv with `Extension (_, n) -> `LExtension (n, fresh_int ())
+   fun e -> match e with `Extension (_, n) -> `LExtension (n, fresh_int ())
 
   let exception_ : Exception.t -> exception_ =
-   fun e -> match e.iv with `Exception (_, n) -> `LException (n, fresh_int ())
+   fun e -> match e with `Exception (_, n) -> `LException (n, fresh_int ())
 
   let value : Value.t -> value =
-   fun v -> match v.iv with `Value (_, n) -> `LValue (n, fresh_int ())
+   fun v -> match v with `Value (_, n) -> `LValue (n, fresh_int ())
 
   let class_ : Class.t -> type_ =
-   fun c -> match c.iv with `Class (_, n) -> `LType (n, fresh_int ())
+   fun c -> match c with `Class (_, n) -> `LType (n, fresh_int ())
 
   let class_type : ClassType.t -> type_ =
-   fun c -> match c.iv with `ClassType (_, n) -> `LType (n, fresh_int ())
+   fun c -> match c with `ClassType (_, n) -> `LType (n, fresh_int ())
 
   let method_ : Method.t -> method_ =
-   fun c -> match c.iv with `Method (_, n) -> `LMethod (n, fresh_int ())
+   fun c -> match c with `Method (_, n) -> `LMethod (n, fresh_int ())
 
   let instance_variable : InstanceVariable.t -> instance_variable =
    fun i ->
-    match i.iv with
+    match i with
     | `InstanceVariable (_, n) -> `LInstanceVariable (n, fresh_int ())
 
   let label : Label.t -> label =
-   fun l -> match l.iv with `Label (_, n) -> `LLabel (n, fresh_int ())
+   fun l -> match l with `Label (_, n) -> `LLabel (n, fresh_int ())
 end
 
 module Name = struct

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -52,6 +52,20 @@ let lookup_module map : Ident.module_ -> _ = function
 
 module Opt = Component.Opt
 
+(* Hash-cons converted resolved module paths so that structurally equal paths
+   become physically shared. Marshal preserves physical sharing, so this is what
+   keeps repetitive alias chains small both on disk and in memory. *)
+module HC = Odoc_model.Paths.Path.Resolved.Module.Hashtbl
+
+let hashcons_tbl : Odoc_model.Paths.Path.Resolved.Module.t HC.t = HC.create 1024
+
+let hashcons p =
+  match HC.find_opt hashcons_tbl p with
+  | Some p' -> p'
+  | None ->
+      HC.add hashcons_tbl p p;
+      p
+
 module Path = struct
   let rec module_ map (p : Cpath.module_) : Odoc_model.Paths.Path.Module.t =
     match p with
@@ -125,6 +139,10 @@ module Path = struct
     | `Class _ | `ClassType _ -> failwith "Probably shouldn't happen"
 
   and resolved_module map (p : Cpath.Resolved.module_) :
+      Odoc_model.Paths.Path.Resolved.Module.t =
+    hashcons (resolved_module_inner map p)
+
+  and resolved_module_inner map (p : Cpath.Resolved.module_) :
       Odoc_model.Paths.Path.Resolved.Module.t =
     match p with
     | `Local id ->

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -65,7 +65,7 @@ module Path = struct
         let hidden =
           b
           ||
-          match m.iv with
+          match m with
           | `Module (_, n) -> Odoc_model.Names.ModuleName.is_hidden n
           | _ -> false
         in
@@ -84,7 +84,7 @@ module Path = struct
     match p with
     | `Substituted x -> `SubstitutedMT (module_type map x)
     | `Identifier
-        (({ iv = #Odoc_model.Paths.Identifier.ModuleType.t_pv; _ } as y), b) ->
+        ((#Odoc_model.Paths.Identifier.ModuleType.t as y), b) ->
         `Identifier (y, b)
     | `Local (id, b) ->
         `Identifier
@@ -101,7 +101,7 @@ module Path = struct
     match p with
     | `Substituted x -> `SubstitutedT (type_ map x)
     | `Identifier
-        (({ iv = #Odoc_model.Paths.Identifier.Path.Type.t_pv; _ } as y), b) ->
+        ((#Odoc_model.Paths.Identifier.Path.Type.t as y), b) ->
         `Identifier (y, b)
     | `Unbox x -> `Unbox (type_ map x)
     | `Local (id, b) -> `Identifier (Component.TypeMap.find id map.path_type, b)
@@ -117,7 +117,7 @@ module Path = struct
     match p with
     | `Substituted x -> `SubstitutedCT (class_type map x)
     | `Identifier
-        (({ iv = #Odoc_model.Paths.Identifier.Path.ClassType.t_pv; _ } as y), b)
+        ((#Odoc_model.Paths.Identifier.Path.ClassType.t as y), b)
       ->
         `Identifier (y, b)
     | `Local (id, b) ->

--- a/src/xref2/lang_of.ml
+++ b/src/xref2/lang_of.ml
@@ -83,8 +83,7 @@ module Path = struct
       Odoc_model.Paths.Path.ModuleType.t =
     match p with
     | `Substituted x -> `SubstitutedMT (module_type map x)
-    | `Identifier
-        ((#Odoc_model.Paths.Identifier.ModuleType.t as y), b) ->
+    | `Identifier ((#Odoc_model.Paths.Identifier.ModuleType.t as y), b) ->
         `Identifier (y, b)
     | `Local (id, b) ->
         `Identifier
@@ -100,8 +99,7 @@ module Path = struct
   and type_ map (p : Cpath.type_) : Odoc_model.Paths.Path.Type.t =
     match p with
     | `Substituted x -> `SubstitutedT (type_ map x)
-    | `Identifier
-        ((#Odoc_model.Paths.Identifier.Path.Type.t as y), b) ->
+    | `Identifier ((#Odoc_model.Paths.Identifier.Path.Type.t as y), b) ->
         `Identifier (y, b)
     | `Unbox x -> `Unbox (type_ map x)
     | `Local (id, b) -> `Identifier (Component.TypeMap.find id map.path_type, b)
@@ -116,9 +114,7 @@ module Path = struct
       =
     match p with
     | `Substituted x -> `SubstitutedCT (class_type map x)
-    | `Identifier
-        ((#Odoc_model.Paths.Identifier.Path.ClassType.t as y), b)
-      ->
+    | `Identifier ((#Odoc_model.Paths.Identifier.Path.ClassType.t as y), b) ->
         `Identifier (y, b)
     | `Local (id, b) ->
         `Identifier (Component.TypeMap.find id map.path_class_type, b)

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -62,7 +62,7 @@ let ambiguous_label_warning label_name labels =
     generated. *)
 let check_ambiguous_label ~loc env
     ( attrs,
-      ({ Odoc_model.Paths.Identifier.iv = `Label (_, label_name); _ } as id),
+      (`Label (_, label_name) as id),
       _ ) =
   if attrs.Comment.heading_label_explicit then
     (* Looking for an identical identifier but a different location. *)

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -60,10 +60,7 @@ let ambiguous_label_warning label_name labels =
 (** Raise a warning when a label explicitly set by the user collides. This
     warning triggers even if one of the colliding labels have been automatically
     generated. *)
-let check_ambiguous_label ~loc env
-    ( attrs,
-      (`Label (_, label_name) as id),
-      _ ) =
+let check_ambiguous_label ~loc env (attrs, (`Label (_, label_name) as id), _) =
   if attrs.Comment.heading_label_explicit then
     (* Looking for an identical identifier but a different location. *)
     let conflicting (`Label (id', comp)) =

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -393,11 +393,7 @@ module L = struct
     let rec find = function
       | hd :: tl -> (
           match Odoc_model.Location_.value hd with
-          | `Heading
-              ( _,
-                (`Label (_, name') as
-                 label),
-                content )
+          | `Heading (_, (`Label (_, name') as label), content)
             when name = LabelName.to_string name' ->
               Ok (`Identifier label, content)
           | _ -> find tl)

--- a/src/xref2/ref_tools.ml
+++ b/src/xref2/ref_tools.ml
@@ -395,7 +395,7 @@ module L = struct
           match Odoc_model.Location_.value hd with
           | `Heading
               ( _,
-                ({ Odoc_model.Paths.Identifier.iv = `Label (_, name'); _ } as
+                (`Label (_, name') as
                  label),
                 content )
             when name = LabelName.to_string name' ->
@@ -455,7 +455,7 @@ module ED = struct
     match te.constructors with
     | [] -> assert false
     | c :: _ ->
-        let id_parent = match id.iv with `Extension (p, _) -> p in
+        let id_parent = match id with `Extension (p, _) -> p in
         Ok
           (`Identifier
              (Identifier.Mk.extension_decl

--- a/src/xref2/shape_tools.cppo.ml
+++ b/src/xref2/shape_tools.cppo.ml
@@ -10,7 +10,7 @@ type t = Shape.t * Odoc_model.Paths.Identifier.SourceLocation.t Shape.Uid.Map.t
 
 (** Project an identifier into a shape. *)
 let rec shape_of_id env :
-    [< Identifier.NonSrc.t_pv ] Identifier.id -> Shape.t option =
+    [< Identifier.NonSrc.t ] -> Shape.t option =
   let proj parent kind name =
     let item = Shape.Item.make name kind in
     match shape_of_id env (parent :> Identifier.NonSrc.t) with
@@ -19,7 +19,7 @@ let rec shape_of_id env :
   in
   fun id ->
     if Identifier.is_hidden id then None else 
-    match id.iv with
+    match id with
     | `Root (_, name) -> (
         match Env.lookup_impl (ModuleName.to_string_unsafe name) env with
         | Some impl -> (

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -734,19 +734,19 @@ and lookup_type_gpath :
   let res =
     match p with
     | `CoreType _ as c -> Ok c
-    | `Identifier ({ iv = `Type _; _ } as i) ->
+    | `Identifier (`Type _ as i) ->
         of_option ~error:(`Lookup_failureT i)
           (Env.(lookup_by_id s_datatype) i env)
-        >>= fun (`Type ({ iv = `Type (_, name); _ }, t)) ->
+        >>= fun (`Type (`Type (_, name), t)) ->
         Ok (`FType (name, t))
-    | `Identifier ({ iv = `Class _; _ } as i) ->
+    | `Identifier (`Class _ as i) ->
         of_option ~error:(`Lookup_failureT i) (Env.(lookup_by_id s_class) i env)
-        >>= fun (`Class ({ iv = `Class (_, name); _ }, t)) ->
+        >>= fun (`Class (`Class (_, name), t)) ->
         Ok (`FClass (name, t))
-    | `Identifier ({ iv = `ClassType _; _ } as i) ->
+    | `Identifier (`ClassType _ as i) ->
         of_option ~error:(`Lookup_failureT i)
           (Env.(lookup_by_id s_class_type) i env)
-        >>= fun (`ClassType ({ iv = `ClassType (_, name); _ }, t)) ->
+        >>= fun (`ClassType (`ClassType (_, name), t)) ->
         Ok (`FClassType (name, t))
     | `CanonicalType (t1, _) -> lookup_type_gpath env t1
     | `Type (p, id) -> do_type p id
@@ -774,9 +774,9 @@ and lookup_value_gpath :
   in
   let res =
     match p with
-    | `Identifier ({ iv = `Value _; _ } as i) ->
+    | `Identifier (`Value _ as i) ->
         of_option ~error:(`Lookup_failureV i) (Env.(lookup_by_id s_value) i env)
-        >>= fun (`Value ({ iv = `Value (_, name); _ }, t)) ->
+        >>= fun (`Value (`Value (_, name), t)) ->
         Ok (`FValue (name, t))
     | `Value (p, id) -> do_value p id
   in
@@ -801,14 +801,14 @@ and lookup_class_type_gpath :
   in
   let res =
     match p with
-    | `Identifier ({ iv = `Class _; _ } as i) ->
+    | `Identifier (`Class _ as i) ->
         of_option ~error:(`Lookup_failureT i) (Env.(lookup_by_id s_class) i env)
-        >>= fun (`Class ({ iv = `Class (_, name); _ }, t)) ->
+        >>= fun (`Class (`Class (_, name), t)) ->
         Ok (`FClass (name, t))
-    | `Identifier ({ iv = `ClassType _; _ } as i) ->
+    | `Identifier (`ClassType _ as i) ->
         of_option ~error:(`Lookup_failureT i)
           (Env.(lookup_by_id s_class_type) i env)
-        >>= fun (`ClassType ({ iv = `ClassType (_, name); _ }, t)) ->
+        >>= fun (`ClassType (`ClassType (_, name), t)) ->
         Ok (`FClassType (name, t))
     | `Class (p, id) -> do_type p id
     | `ClassType (p, id) -> do_type p id
@@ -2311,8 +2311,8 @@ and class_signature_of_class_type :
 let resolve_module_path env p =
   resolve_module env p >>= fun (p, m) ->
   match p with
-  | `Gpath (`Identifier { iv = `Root _; _ })
-  | `Hidden (`Gpath (`Identifier { iv = `Root _; _ })) ->
+  | `Gpath (`Identifier `Root _)
+  | `Hidden (`Gpath (`Identifier `Root _)) ->
       Ok p
   | _ -> (
       let m = Component.Delayed.get m in

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -737,12 +737,10 @@ and lookup_type_gpath :
     | `Identifier (`Type _ as i) ->
         of_option ~error:(`Lookup_failureT i)
           (Env.(lookup_by_id s_datatype) i env)
-        >>= fun (`Type (`Type (_, name), t)) ->
-        Ok (`FType (name, t))
+        >>= fun (`Type (`Type (_, name), t)) -> Ok (`FType (name, t))
     | `Identifier (`Class _ as i) ->
         of_option ~error:(`Lookup_failureT i) (Env.(lookup_by_id s_class) i env)
-        >>= fun (`Class (`Class (_, name), t)) ->
-        Ok (`FClass (name, t))
+        >>= fun (`Class (`Class (_, name), t)) -> Ok (`FClass (name, t))
     | `Identifier (`ClassType _ as i) ->
         of_option ~error:(`Lookup_failureT i)
           (Env.(lookup_by_id s_class_type) i env)
@@ -776,8 +774,7 @@ and lookup_value_gpath :
     match p with
     | `Identifier (`Value _ as i) ->
         of_option ~error:(`Lookup_failureV i) (Env.(lookup_by_id s_value) i env)
-        >>= fun (`Value (`Value (_, name), t)) ->
-        Ok (`FValue (name, t))
+        >>= fun (`Value (`Value (_, name), t)) -> Ok (`FValue (name, t))
     | `Value (p, id) -> do_value p id
   in
   res
@@ -803,8 +800,7 @@ and lookup_class_type_gpath :
     match p with
     | `Identifier (`Class _ as i) ->
         of_option ~error:(`Lookup_failureT i) (Env.(lookup_by_id s_class) i env)
-        >>= fun (`Class (`Class (_, name), t)) ->
-        Ok (`FClass (name, t))
+        >>= fun (`Class (`Class (_, name), t)) -> Ok (`FClass (name, t))
     | `Identifier (`ClassType _ as i) ->
         of_option ~error:(`Lookup_failureT i)
           (Env.(lookup_by_id s_class_type) i env)
@@ -2311,8 +2307,7 @@ and class_signature_of_class_type :
 let resolve_module_path env p =
   resolve_module env p >>= fun (p, m) ->
   match p with
-  | `Gpath (`Identifier `Root _)
-  | `Hidden (`Gpath (`Identifier `Root _)) ->
+  | `Gpath (`Identifier (`Root _)) | `Hidden (`Gpath (`Identifier (`Root _))) ->
       Ok p
   | _ -> (
       let m = Component.Delayed.get m in

--- a/test/xref2/aliaschain.t/run.t
+++ b/test/xref2/aliaschain.t/run.t
@@ -5,4 +5,3 @@ size.
   $ odoc compile chain.cmti
   $ odoc link chain.odoc -I .
   $ find . -name chain.odocl -size +100000c 
-  ./chain.odocl

--- a/test/xref2/lib/common.cppo.ml
+++ b/test/xref2/lib/common.cppo.ml
@@ -386,7 +386,7 @@ module LangUtils = struct
                 let rec inner = function
                     | Odoc_model.Lang.Signature.Module (_, m) :: rest -> begin
                         let id = m.Odoc_model.Lang.Module.id in
-                        match id.iv with
+                        match id with
                         | `Module (_, mname') ->
                             if ModuleName.to_string mname' = mname
                             then m
@@ -413,7 +413,7 @@ module LangUtils = struct
         type 'a fmt = Format.formatter -> 'a -> unit
 
         open Paths
-        val identifier : [< Identifier.t_pv] Paths.Identifier.id fmt
+        val identifier : [< Identifier.t] fmt
 
         open Lang
 


### PR DESCRIPTION
This simplification is the removal of an optimisation that's measurably unnecessary now. The end result is something that runs just as fast as before, but with a large decrease in memory and disk usage. The reduction in disk space is around 30% overall. The memory usage decreases by a lot less - around 5%.
