### PR TITLE
Fix canonical chain search

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
 - Fix odoc_driver's detection of `stdlib` when it is in `$prefix/lib64`, requires ocamlfind >= 1.9.8 (@katrinafyi, #1477, #1474)
 - Fix loss of items bound by extended opens (`open struct ... end`) following a top-of-file docstring (@jonludlam, #1482)
 - Fix resolution of paths through the bindings of an extended open (@jonludlam, #1482)
+- Don't let an unrelated `@canonical` tag halt the search for a self-canonical
+  module, which lost the expansion of the module it named (@jonludlam, #1483)
 
 ### Performance
 - Cache Shape_reduce functor instantiation per environment during source resolution (@jonludlam, #1487)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,8 +20,7 @@
 - Fix odoc_driver's detection of `stdlib` when it is in `$prefix/lib64`, requires ocamlfind >= 1.9.8 (@katrinafyi, #1477, #1474)
 - Fix loss of items bound by extended opens (`open struct ... end`) following a top-of-file docstring (@jonludlam, #1482)
 - Fix resolution of paths through the bindings of an extended open (@jonludlam, #1482)
-- Don't let an unrelated `@canonical` tag halt the search for a self-canonical
-  module, which lost the expansion of the module it named (@jonludlam, #1483)
+- Unresolved @canonical tags no longer abort the search for canonical paths (@jonludlam, #1483)
 
 ### Performance
 - Cache Shape_reduce functor instantiation per environment during source resolution (@jonludlam, #1487)

--- a/src/xref2/tools.ml
+++ b/src/xref2/tools.ml
@@ -1337,13 +1337,14 @@ and handle_canonical_module_real env p2 =
                    If not, check for an alias chain with us as canonical in it... *)
                 let rec check m =
                   match m.Component.Module.canonical with
-                  | Some p ->
-                      p = p2
-                      (* The canonical path is the same one we're trying to resolve *)
-                  | None -> (
+                  | Some p when p = p2 -> true
+                  | _ -> (
+                      (* An unrelated canonical tag - Dune tags every alias with
+                         [Lib.M], even ones [lib.ml] doesn't re-export - mustn't
+                         stop the search: a module further down the chain may
+                         still be the one we're looking for. *)
                       match m.type_ with
                       | Component.Module.Alias (p, _) -> (
-                          (* Format.eprintf "Going to resolve %a\n%!" Component.Fmt.module_path p; *)
                           match resolve_module env p with
                           | Ok (rp, _) -> (
                               match lookup_module env rp with

--- a/test/xref2/canonical_missing_alias.t/main.ml
+++ b/test/xref2/canonical_missing_alias.t/main.ml
@@ -1,0 +1,11 @@
+open Main__
+
+module Foo = Foo
+
+(* [Zone] is exposed here, but under a different name - so [Main.Zone], the
+   canonical path Dune put on the alias in [main__.ml], does not exist. *)
+module Private = struct
+  module Zone_alias = Zone
+end
+
+let zone_name = Zone.name

--- a/test/xref2/canonical_missing_alias.t/main__.ml
+++ b/test/xref2/canonical_missing_alias.t/main__.ml
@@ -1,0 +1,5 @@
+(** @canonical Main.Zone *)
+module Zone = Main__Zone
+
+(** @canonical Main.Foo *)
+module Foo = Main__Foo

--- a/test/xref2/canonical_missing_alias.t/main__Foo.mli
+++ b/test/xref2/canonical_missing_alias.t/main__Foo.mli
@@ -1,0 +1,1 @@
+val f : Zone.t -> int

--- a/test/xref2/canonical_missing_alias.t/main__Zone.mli
+++ b/test/xref2/canonical_missing_alias.t/main__Zone.mli
@@ -1,0 +1,3 @@
+type t
+
+val name : t -> string

--- a/test/xref2/canonical_missing_alias.t/run.t
+++ b/test/xref2/canonical_missing_alias.t/run.t
@@ -1,0 +1,135 @@
+This test reproduces a problem seen in real libraries (Jane Street's `core`
+being the motivating example) that use Dune's wrapping together with a
+hand-written top-level module.
+
+Dune generates the alias module `main__.ml` with a canonical tag `Main.M` for
+every module `M` in the library. When `main.ml` is hand-written, it is up to
+the author to re-export those modules under exactly those names. If a module
+is re-exported under a *different* name - or not at all - the canonical path
+Dune wrote down doesn't exist, and references to that module can't be
+resolved. See `doc/dune.mld` for a description of the wrapping scheme.
+
+Here `Zone` is a module of the library:
+
+  $ cat main__Zone.mli
+  type t
+  
+  val name : t -> string
+
+
+`main__Foo.mli` refers to it, so `Zone.t` will end up in `Main.Foo`'s
+signature:
+
+  $ cat main__Foo.mli
+  val f : Zone.t -> int
+
+This is the alias module Dune generates. Note the canonical tag on `Zone`
+pointing at `Main.Zone`:
+
+  $ cat main__.ml
+  (** @canonical Main.Zone *)
+  module Zone = Main__Zone
+  
+  (** @canonical Main.Foo *)
+  module Foo = Main__Foo
+
+
+But the hand-written `main.ml` doesn't have a `Zone` alias - it exposes the
+module under a different name, so `Main.Zone` never exists:
+
+  $ cat main.ml
+  open Main__
+  
+  module Foo = Foo
+  
+  (* [Zone] is exposed here, but under a different name - so [Main.Zone], the
+     canonical path Dune put on the alias in [main__.ml], does not exist. *)
+  module Private = struct
+    module Zone_alias = Zone
+  end
+  
+  let zone_name = Zone.name
+
+
+
+
+Build it the way Dune does: the alias module first, with `-no-alias-deps`, and
+everything else with `-open Main__`.
+
+  $ ocamlc -c -bin-annot -no-alias-deps -w -49 main__.ml
+  $ ocamlc -c -bin-annot -no-alias-deps main__Zone.mli
+  $ ocamlc -c -bin-annot -no-alias-deps -open Main__ main__Foo.mli
+  $ ocamlc -c -bin-annot -no-alias-deps -open Main__ main.ml
+
+  $ odoc compile -I . main__Zone.cmti
+  $ odoc compile -I . main__.cmt
+  $ odoc compile -I . main__Foo.cmti
+  $ odoc compile -I . main.cmt
+  $ odoc link -I . main.odoc
+  $ odoc html-generate --indent -o html main.odocl
+
+`Main.Private.Zone_alias` is documented, since it's an alias of a hidden
+module and so gets expanded:
+
+  $ find html/Main -name index.html | sort
+  html/Main/Foo/index.html
+  html/Main/Private/Zone_alias/index.html
+  html/Main/Private/index.html
+  html/Main/index.html
+
+But the reference in `Main.Foo` is unresolved: the canonical path `Main.Zone`
+can't be resolved, and odoc has no way of knowing that
+`Main.Private.Zone_alias` names the same module.
+
+  $ grep -A3 'val</span> f' html/Main/Foo/index.html
+        <span><span class="keyword">val</span> f : 
+         <span><span class="xref-unresolved">Main__.Zone.t</span> 
+          <span class="arrow">&#45;&gt;</span>
+         </span> int
+
+The fix is to give `Zone` a canonical path that actually exists. The tag Dune
+generates can't be changed, but a canonical tag in the module's own preamble
+takes precedence over it, so the library author can correct it from
+`main__Zone.mli`:
+
+  $ sed -i '1i (** @canonical Main.Private.Zone_alias *)\n' main__Zone.mli
+  $ cat main__Zone.mli
+  (** @canonical Main.Private.Zone_alias *)
+  
+  type t
+  
+  val name : t -> string
+
+
+
+  $ rm -rf html *.cm* *.odoc *.odocl
+  $ ocamlc -c -bin-annot -no-alias-deps -w -49 main__.ml
+  $ ocamlc -c -bin-annot -no-alias-deps main__Zone.mli
+  $ ocamlc -c -bin-annot -no-alias-deps -open Main__ main__Foo.mli
+  $ ocamlc -c -bin-annot -no-alias-deps -open Main__ main.ml
+
+  $ odoc compile -I . main__Zone.cmti
+  $ odoc compile -I . main__.cmt
+  $ odoc compile -I . main__Foo.cmti
+  $ odoc compile -I . main.cmt
+  $ odoc link -I . main.odoc
+  $ odoc html-generate --indent -o html main.odocl
+
+`Main.Private.Zone_alias` should still be documented - it must not lose its
+expansion just because it is now the canonical destination of the module it is
+an alias of. But its page has gone:
+
+  $ find html/Main -name index.html | sort
+  html/Main/Foo/index.html
+  html/Main/Private/index.html
+  html/Main/index.html
+
+and while the reference now names the right module, it is rendered as plain
+text rather than a link to it:
+
+  $ grep -A4 'val</span> f' html/Main/Foo/index.html
+        <span><span class="keyword">val</span> f : 
+         <span>Private.Zone_alias.t <span class="arrow">&#45;&gt;</span></span>
+          int
+        </span>
+       </code>

--- a/test/xref2/canonical_missing_alias.t/run.t
+++ b/test/xref2/canonical_missing_alias.t/run.t
@@ -115,21 +115,21 @@ takes precedence over it, so the library author can correct it from
   $ odoc link -I . main.odoc
   $ odoc html-generate --indent -o html main.odocl
 
-`Main.Private.Zone_alias` should still be documented - it must not lose its
-expansion just because it is now the canonical destination of the module it is
-an alias of. But its page has gone:
+`Main.Private.Zone_alias` is still documented - it must not lose its expansion
+just because it is now the canonical destination of the module it is an alias
+of:
 
   $ find html/Main -name index.html | sort
   html/Main/Foo/index.html
+  html/Main/Private/Zone_alias/index.html
   html/Main/Private/index.html
   html/Main/index.html
 
-and while the reference now names the right module, it is rendered as plain
-text rather than a link to it:
+and the reference resolves, and links to it:
 
   $ grep -A4 'val</span> f' html/Main/Foo/index.html
         <span><span class="keyword">val</span> f : 
-         <span>Private.Zone_alias.t <span class="arrow">&#45;&gt;</span></span>
-          int
-        </span>
-       </code>
+         <span>
+          <a href="../Private/Zone_alias/index.html#type-t">
+           Private.Zone_alias.t
+          </a> <span class="arrow">&#45;&gt;</span>

--- a/test/xref2/canonical_missing_alias.t/run.t
+++ b/test/xref2/canonical_missing_alias.t/run.t
@@ -92,7 +92,7 @@ generates can't be changed, but a canonical tag in the module's own preamble
 takes precedence over it, so the library author can correct it from
 `main__Zone.mli`:
 
-  $ sed -i '1i (** @canonical Main.Private.Zone_alias *)\n' main__Zone.mli
+  $ printf '(** @canonical Main.Private.Zone_alias *)\n\n' | cat - main__Zone.mli > t && mv t main__Zone.mli
   $ cat main__Zone.mli
   (** @canonical Main.Private.Zone_alias *)
   

--- a/test/xref2/canonical_missing_alias.t/run.t
+++ b/test/xref2/canonical_missing_alias.t/run.t
@@ -54,19 +54,23 @@ module under a different name, so `Main.Zone` never exists:
 
 
 Build it the way Dune does: the alias module first, with `-no-alias-deps`, and
-everything else with `-open Main__`.
+everything else with `-open Main__`. This is a function because we run the
+exact same steps again after fixing the canonical tag below.
 
-  $ ocamlc -c -bin-annot -no-alias-deps -w -49 main__.ml
-  $ ocamlc -c -bin-annot -no-alias-deps main__Zone.mli
-  $ ocamlc -c -bin-annot -no-alias-deps -open Main__ main__Foo.mli
-  $ ocamlc -c -bin-annot -no-alias-deps -open Main__ main.ml
+  $ build () {
+  >   ocamlc -c -bin-annot -no-alias-deps -w -49 main__.ml
+  >   ocamlc -c -bin-annot -no-alias-deps main__Zone.mli
+  >   ocamlc -c -bin-annot -no-alias-deps -open Main__ main__Foo.mli
+  >   ocamlc -c -bin-annot -no-alias-deps -open Main__ main.ml
+  >   odoc compile -I . main__Zone.cmti
+  >   odoc compile -I . main__.cmt
+  >   odoc compile -I . main__Foo.cmti
+  >   odoc compile -I . main.cmt
+  >   odoc link -I . main.odoc
+  >   odoc html-generate --indent -o html main.odocl
+  > }
 
-  $ odoc compile -I . main__Zone.cmti
-  $ odoc compile -I . main__.cmt
-  $ odoc compile -I . main__Foo.cmti
-  $ odoc compile -I . main.cmt
-  $ odoc link -I . main.odoc
-  $ odoc html-generate --indent -o html main.odocl
+  $ build
 
 `Main.Private.Zone_alias` is documented, since it's an alias of a hidden
 module and so gets expanded:
@@ -103,17 +107,7 @@ takes precedence over it, so the library author can correct it from
 
 
   $ rm -rf html *.cm* *.odoc *.odocl
-  $ ocamlc -c -bin-annot -no-alias-deps -w -49 main__.ml
-  $ ocamlc -c -bin-annot -no-alias-deps main__Zone.mli
-  $ ocamlc -c -bin-annot -no-alias-deps -open Main__ main__Foo.mli
-  $ ocamlc -c -bin-annot -no-alias-deps -open Main__ main.ml
-
-  $ odoc compile -I . main__Zone.cmti
-  $ odoc compile -I . main__.cmt
-  $ odoc compile -I . main__Foo.cmti
-  $ odoc compile -I . main.cmt
-  $ odoc link -I . main.odoc
-  $ odoc html-generate --indent -o html main.odocl
+  $ build
 
 `Main.Private.Zone_alias` is still documented - it must not lose its expansion
 just because it is now the canonical destination of the module it is an alias


### PR DESCRIPTION
This is an enabling PR - it allows people to fix the problems that happen when you write your own wrapper module that doesn't contain _all_ of the library's modules. You should be able to put @canonical tags in the appropriate places after this.
