### PR TITLE
Fix broken test for hidden paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 - Unresolved @canonical tags no longer abort the search for canonical paths (@jonludlam, #1483)
 - Compress the contents of `.odoc` and `.odocl` files, which makes them several
   times smaller (@jonludlam, #1486)
+- Fix bug in hidden name check that sometimes exposed hidden items (@jonludlam, #1484)
 
 ### Performance
 - Cache Shape_reduce functor instantiation per environment during source resolution (@jonludlam, #1487)

--- a/src/xref2/cpath.ml
+++ b/src/xref2/cpath.ml
@@ -254,7 +254,7 @@ and is_resolved_type_hidden : Resolved.type_ -> bool = function
   | `Unbox p -> is_resolved_type_hidden p
   (* A shadowed or otherwise hidden name makes the path hidden even when its
      parent is visible - as in [Odoc_model.Paths.Path.Resolved.is_hidden]. *)
-  | `Type (_, n) | `Class (_, n) | `ClassType (_, n) when TypeName.is_hidden n
+  | (`Type (_, n) | `Class (_, n) | `ClassType (_, n)) when TypeName.is_hidden n
     ->
       true
   | `Type (p, _) | `Class (p, _) | `ClassType (p, _) ->

--- a/src/xref2/cpath.ml
+++ b/src/xref2/cpath.ml
@@ -252,6 +252,11 @@ and is_resolved_type_hidden : Resolved.type_ -> bool = function
   | `CanonicalType (_, `Resolved _) -> false
   | `CanonicalType (p, _) -> is_resolved_type_hidden p
   | `Unbox p -> is_resolved_type_hidden p
+  (* A shadowed or otherwise hidden name makes the path hidden even when its
+     parent is visible - as in [Odoc_model.Paths.Path.Resolved.is_hidden]. *)
+  | `Type (_, n) | `Class (_, n) | `ClassType (_, n) when TypeName.is_hidden n
+    ->
+      true
   | `Type (p, _) | `Class (p, _) | `ClassType (p, _) ->
       is_resolved_parent_hidden ~weak_canonical_test:false p
 

--- a/test/xref2/shadowed_name_render.t/run.t
+++ b/test/xref2/shadowed_name_render.t/run.t
@@ -37,12 +37,12 @@ the internal disambiguated name:
 
   $ grep -A4 'val</span> equal' html/Test/N/index.html
         <span><span class="keyword">val</span> equal : 
-                                                         
-         <span>
-          <span class="xref-unresolved">
-           M.{t}1/shadowed/(6136b1bde48b84021ec2033e9708772d)
+         <span>int <span class="arrow">&#45;&gt;</span></span> 
+         <span>int <span class="arrow">&#45;&gt;</span></span> bool
+        </span>
+       </code>
 
 Nothing anywhere in the output should contain the internal form:
 
   $ grep -rl 'shadowed/(' html/ || echo "no internal names leaked"
-  html/Test/N/index.html
+  no internal names leaked

--- a/test/xref2/shadowed_name_render.t/run.t
+++ b/test/xref2/shadowed_name_render.t/run.t
@@ -1,0 +1,48 @@
+When a signature item is shadowed by a later one, odoc gives the shadowed item
+a disambiguated internal name so that it still has a unique identifier. That
+name must never reach the output.
+
+Here `M`'s first `t` is shadowed by the second `include`, but `M.R` still
+refers to the first one, and `N` is `module type of M.R` (the shape of core's
+`std_internal.ml`, which does `include Int.Replace_polymorphic_compare`):
+
+  $ cat test.mli
+  module type Has_t = sig
+    type t = int
+  
+    module R : sig
+      val equal : t -> t -> bool
+    end
+  end
+  
+  module M : sig
+    include Has_t
+  
+    (** Shadows the [t] above - [R] still refers to the first one. *)
+    include sig
+      type nonrec t = t
+    end
+  end
+  
+  module N : module type of M.R
+
+  $ ocamlc -c -bin-annot test.mli
+  $ odoc compile test.cmti
+  $ odoc link test.odoc
+  $ odoc html-generate --indent -o html test.odocl
+
+The shadowed `t` is `int`, and the compiler only permits the shadowing because
+that makes it re-expressible. odoc should say so, rather than falling back on
+the internal disambiguated name:
+
+  $ grep -A4 'val</span> equal' html/Test/N/index.html
+        <span><span class="keyword">val</span> equal : 
+                                                         
+         <span>
+          <span class="xref-unresolved">
+           M.{t}1/shadowed/(6136b1bde48b84021ec2033e9708772d)
+
+Nothing anywhere in the output should contain the internal form:
+
+  $ grep -rl 'shadowed/(' html/ || echo "no internal names leaked"
+  html/Test/N/index.html

--- a/test/xref2/shadowed_name_render.t/test.mli
+++ b/test/xref2/shadowed_name_render.t/test.mli
@@ -1,0 +1,18 @@
+module type Has_t = sig
+  type t = int
+
+  module R : sig
+    val equal : t -> t -> bool
+  end
+end
+
+module M : sig
+  include Has_t
+
+  (** Shadows the [t] above - [R] still refers to the first one. *)
+  include sig
+    type nonrec t = t
+  end
+end
+
+module N : module type of M.R


### PR DESCRIPTION
We were only checking if a type's _parent_ was hidden, not the type's name itself.