### PR TITLE
Build the shape reducer once rather than many times

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
 - Fix resolving functor through `module type of` (@Leonidas-from-XIV, #1471)
 - Fix odoc_driver's detection of `stdlib` when it is in `$prefix/lib64`, requires ocamlfind >= 1.9.8 (@katrinafyi, #1477, #1474)
 
+### Performance
+- Cache Shape_reduce functor instantiation per environment during source resolution (@jonludlam, #XXXX)
+
 # 3.2.1
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 - Fix odoc_driver's detection of `stdlib` when it is in `$prefix/lib64`, requires ocamlfind >= 1.9.8 (@katrinafyi, #1477, #1474)
 
 ### Performance
-- Cache Shape_reduce functor instantiation per environment during source resolution (@jonludlam, #XXXX)
+- Cache Shape_reduce functor instantiation per environment during source resolution (@jonludlam, #1487)
 
 # 3.2.1
 

--- a/src/.ocamlformat-ignore
+++ b/src/.ocamlformat-ignore
@@ -14,6 +14,6 @@ syntax_highlighter/syntax_highlighter.ml
 model/*.cppo.ml
 odoc/*.cppo.ml
 html_support_files/*.ml
-xref2/shape_tools.*
+xref2/shape_*
 odoc/classify.cppo.ml
 

--- a/src/odoc/resolver.ml
+++ b/src/odoc/resolver.ml
@@ -537,8 +537,16 @@ let build_compile_env_for_unit
   and lookup_page _ = Error `Not_found
   and lookup_asset _ = Error `Not_found
   and lookup_impl = lookup_impl ap in
+  let shape_reducer = Odoc_xref2.Shape_reducer.make ~lookup_impl in
   let resolver =
-    { Env.open_units; lookup_unit; lookup_page; lookup_impl; lookup_asset }
+    {
+      Env.open_units;
+      lookup_unit;
+      lookup_page;
+      lookup_impl;
+      lookup_asset;
+      shape_reducer;
+    }
   in
   Env.env_of_unit m ~linking:false resolver
 
@@ -564,7 +572,15 @@ let build ?(imports_map = StringMap.empty) ?hierarchy_roots
   and lookup_page = lookup_page ap ~pages ~hierarchy
   and lookup_asset = lookup_asset ~pages ~hierarchy
   and lookup_impl = lookup_impl ap in
-  { Env.open_units; lookup_unit; lookup_page; lookup_impl; lookup_asset }
+  let shape_reducer = Odoc_xref2.Shape_reducer.make ~lookup_impl in
+  {
+    Env.open_units;
+    lookup_unit;
+    lookup_page;
+    lookup_impl;
+    lookup_asset;
+    shape_reducer;
+  }
 
 let build_compile_env_for_impl t i =
   let imports_map =

--- a/src/xref2/dune
+++ b/src/xref2/dune
@@ -32,3 +32,29 @@
  (with-stdout-to
   shape_tools.mli
   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{dep:shape_tools.cppo.mli})))
+
+(rule
+ (enabled_if
+  (not %{ocaml-config:ox}))
+ (action
+  (with-stdout-to
+   shape_reducer.ml
+   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{dep:shape_reducer.cppo.ml}))))
+
+(rule
+ (enabled_if %{ocaml-config:ox})
+ (action
+  (with-stdout-to
+   shape_reducer.ml
+   (run
+    %{bin:cppo}
+    -V
+    OCAML:%{ocaml_version}
+    -D
+    OXCAML
+    %{dep:shape_reducer.cppo.ml}))))
+
+(rule
+ (with-stdout-to
+  shape_reducer.mli
+  (run %{bin:cppo} -V OCAML:%{ocaml_version} %{dep:shape_reducer.cppo.mli})))

--- a/src/xref2/env.ml
+++ b/src/xref2/env.ml
@@ -16,6 +16,7 @@ type resolver = {
   lookup_page : path_query -> (Lang.Page.t, lookup_error) result;
   lookup_asset : path_query -> (Lang.Asset.t, lookup_error) result;
   lookup_impl : string -> Lang.Implementation.t option;
+  shape_reducer : Shape_reducer.t;
 }
 
 type root =
@@ -188,6 +189,8 @@ let is_linking env = env.linking
 let set_resolver t resolver = { t with resolver = Some resolver }
 
 let has_resolver t = match t.resolver with None -> false | _ -> true
+
+let resolver t = t.resolver
 
 let id t = t.id
 

--- a/src/xref2/env.mli
+++ b/src/xref2/env.mli
@@ -15,6 +15,7 @@ type resolver = {
   lookup_page : path_query -> (Lang.Page.t, lookup_error) result;
   lookup_asset : path_query -> (Lang.Asset.t, lookup_error) result;
   lookup_impl : string -> Lang.Implementation.t option;
+  shape_reducer : Shape_reducer.t;
 }
 
 type root =
@@ -43,6 +44,8 @@ val with_recorded_lookups : t -> (t -> 'a) -> LookupTypeSet.t * 'a
 val set_resolver : t -> resolver -> t
 
 val has_resolver : t -> bool
+
+val resolver : t -> resolver option
 
 val id : t -> int
 

--- a/src/xref2/shape_reducer.cppo.ml
+++ b/src/xref2/shape_reducer.cppo.ml
@@ -1,0 +1,63 @@
+#if OCAML_VERSION >= (4, 14, 0)
+
+type t = Shape.t -> Shape.Uid.t option
+
+#if OCAML_VERSION >= (5, 2, 0)
+let rec traverse_aliases = function
+  | Shape_reduce.Resolved uid -> Some uid
+  | Approximated id -> id
+  | Resolved_alias (_, x) -> traverse_aliases x
+  | _ -> None
+#endif
+
+let make ~lookup_impl =
+  let read_unit_shape ~unit_name =
+    match lookup_impl unit_name with
+    | Some impl -> (
+        match impl.Odoc_model.Lang.Implementation.shape_info with
+        | Some (shape, _) -> Some shape
+        | None -> None)
+    | None -> None
+  in
+#if OCAML_VERSION < (5, 2, 0)
+  let module Reduce = Shape.Make_reduce (struct
+    type env = unit
+    let fuel = 10
+    let read_unit_shape ~unit_name = read_unit_shape ~unit_name
+    let find_shape _ _ = raise Not_found
+  end) in
+  fun query ->
+    match (try Some (Reduce.reduce () query) with Not_found -> None) with
+    | Some result -> result.uid
+    | None -> None
+#else
+  let module Reduce = Shape_reduce.Make (struct
+    let fuel = 10
+    let read_unit_shape ~unit_name = read_unit_shape ~unit_name
+#if defined OXCAML
+    let fuel () = Misc.Maybe_bounded.of_int 10
+    let fuel_for_compilation_units () = Misc.Maybe_bounded.Unbounded
+    let max_shape_reduce_steps_per_variable () = Misc.Maybe_bounded.Unbounded
+    let max_compilation_unit_depth () = Misc.Maybe_bounded.Unbounded
+    let projection_rules_for_merlin_enabled = true
+    let read_unit_shape ~diagnostics:_ ~unit_name = read_unit_shape ~unit_name
+#endif
+  end) in
+  fun query ->
+    match
+      (try Some (Reduce.reduce_for_uid Odoc_model.Paths.Ocaml_env.empty query)
+       with Not_found -> None)
+    with
+    | Some r -> traverse_aliases r
+    | None -> None
+#endif
+
+let reduce_for_uid t shape = t shape
+
+#else
+
+type t = unit
+
+let make ~lookup_impl:_ = ()
+
+#endif

--- a/src/xref2/shape_reducer.cppo.mli
+++ b/src/xref2/shape_reducer.cppo.mli
@@ -1,0 +1,12 @@
+(* Shape reduction, built once per resolver and stored in it. The reducer
+   owns the memoisation tables of [Shape_reduce.Make], so queries made
+   through the same resolver share work. *)
+
+type t
+
+val make :
+  lookup_impl:(string -> Odoc_model.Lang.Implementation.t option) -> t
+
+#if OCAML_VERSION >= (4, 14, 0)
+val reduce_for_uid : t -> Shape.t -> Shape.Uid.t option
+#endif

--- a/src/xref2/shape_tools.cppo.ml
+++ b/src/xref2/shape_tools.cppo.ml
@@ -125,54 +125,10 @@ let unit_of_uid uid =
   | Local_opaque_item _ -> None
 #endif
 
-#if OCAML_VERSION >= (5,2,0)
-let rec traverse_aliases = function
-   | Shape_reduce.Resolved uid -> Some uid
-   | Approximated id -> id
-   | Resolved_alias (_,x) -> traverse_aliases x
-   | _ -> None
-#endif
-
 let lookup_shape : Env.t -> Shape.t -> Identifier.SourceLocation.t option =
  fun env query ->
-#if OCAML_VERSION < (5,2,0)
-  let module Reduce = Shape.Make_reduce (struct
-    type env = unit
-    let fuel = 10
-    let read_unit_shape ~unit_name =
-      match Env.lookup_impl unit_name env with
-      | Some impl -> (
-          match impl.shape_info with
-          | Some (shape, _) -> Some shape
-          | None -> None)
-      | _ -> None
-    let find_shape _ _ = raise Not_found
-  end) in
-  let result = try Some (Reduce.reduce () query) with Not_found -> None in
-  result >>= fun result ->
-  result.uid >>= fun uid ->
-#else
-  let module Reduce = Shape_reduce.Make(struct
-    let fuel = 10
-    let read_unit_shape ~unit_name =
-      match Env.lookup_impl unit_name env with
-      | Some impl -> (
-          match impl.shape_info with
-          | Some (shape, _) -> Some shape
-          | None -> None)
-       | _ -> None
-#if defined OXCAML
-    let fuel () = Misc.Maybe_bounded.of_int 10
-    let fuel_for_compilation_units () = Misc.Maybe_bounded.Unbounded
-    let max_shape_reduce_steps_per_variable () = Misc.Maybe_bounded.Unbounded
-    let max_compilation_unit_depth () = Misc.Maybe_bounded.Unbounded
-    let projection_rules_for_merlin_enabled = true
-    let read_unit_shape ~diagnostics:_ ~unit_name = read_unit_shape ~unit_name
-#endif
-  end) in
-  let result = try Some (Reduce.reduce_for_uid Ocaml_env.empty query) with Not_found -> None in
-  result >>= traverse_aliases >>= fun uid ->
-#endif
+  Env.resolver env >>= fun resolver ->
+  Shape_reducer.reduce_for_uid resolver.Env.shape_reducer query >>= fun uid ->
   unit_of_uid uid >>= fun unit_name ->
   match Env.lookup_impl unit_name env with
   | Some { shape_info ; id = Some id ; _} -> (


### PR DESCRIPTION
We can share its caches as a result, which massively reduces allocation.