### PR TITLE
Odoc merge word runs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@
 ### Performance
 - Memoize doc-comment parsing and skip doc rebuilding during link when nothing needs resolution (@jonludlam, #1480)
 
+### Performance
+- Memoize doc-comment parsing and skip doc rebuilding during link when nothing needs resolution (@jonludlam, #1480)
+
 ### Fixed
 - Fix optional arguments rendering as `?arg:???` in modules without an mli on
   OCaml 5.5 (@jonludlam, #1489)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
 
 ### Performance
 - Memoize doc-comment parsing and skip doc rebuilding during link when nothing needs resolution (@jonludlam, #1480)
+- Store comment text as one node per run of words rather than one per word,
+  which makes `.odoc` and `.odocl` files substantially smaller (@jonludlam, #1487)
 
 ### Fixed
 - Fix optional arguments rendering as `?arg:???` in modules without an mli on

--- a/src/document/comment.ml
+++ b/src/document/comment.ml
@@ -148,9 +148,26 @@ module Reference = struct
             [ inline @@ Inline.Link link ])
 end
 
+(* Merged word runs keep the source whitespace, which isn't significant
+   inline, so collapse each run to a single space for rendering. *)
+let collapse_whitespace s =
+  let b = Buffer.create (Stdlib.String.length s) in
+  let in_ws = ref false in
+  Stdlib.String.iter
+    (fun c ->
+      match c with
+      | ' ' | '\t' | '\n' | '\r' ->
+          if not !in_ws then Buffer.add_char b ' ';
+          in_ws := true
+      | c ->
+          Buffer.add_char b c;
+          in_ws := false)
+    s;
+  Buffer.contents b
+
 let leaf_inline_element : Comment.leaf_inline_element -> Inline.one = function
-  | `Space -> inline @@ Text " "
-  | `Word s -> inline @@ Text s
+  | `Space s -> inline @@ Text (collapse_whitespace s)
+  | `Word s -> inline @@ Text (collapse_whitespace s)
   | `Code_span s -> inline @@ Source (source_of_code s)
   | `Math_span s -> inline @@ Math s
   | `Raw_markup (target, s) -> inline @@ Raw_markup (target, s)

--- a/src/loader/doc_attr.ml
+++ b/src/loader/doc_attr.ml
@@ -237,7 +237,9 @@ let attached ~warnings_tag internal_tags parent attrs =
                   let parsed =
                     Odoc_parser.parse_comment ~location:(pad_loc loc) ~text:str
                   in
-                  let ast = Error.raise_parser_warnings parsed in
+                  let ast =
+                    Semantics.merge_ast (Error.raise_parser_warnings parsed)
+                  in
                   (match Odoc_parser.warnings parsed with
                   | [] when not (ast_needs_own_location ast) ->
                       Hashtbl.replace doc_cache str ast

--- a/src/model/comment.ml
+++ b/src/model/comment.ml
@@ -15,7 +15,7 @@ type media = [ `Image | `Audio | `Video ]
 type raw_markup_target = string
 
 type leaf_inline_element =
-  [ `Space
+  [ `Space of string
   | `Word of string
   | `Code_span of string
   | `Math_span of string
@@ -155,7 +155,7 @@ let to_string (l : link_content) =
     | `Code_span s -> s
     | `Word w -> w
     | `Math_span m -> m
-    | `Space -> " "
+    | `Space s -> s
     | `Styled (_, is) -> s_of_is is
     | `Raw_markup (_, r) -> r
   and s_of_is is =

--- a/src/model/frontmatter.ml
+++ b/src/model/frontmatter.ml
@@ -77,7 +77,7 @@ let parse_children_order loc (co : tag_payload) =
     | [] -> Ok (Location_.at loc (Children_order (List.rev acc)))
     | ({ Location_.value = `Word word; _ } as w) :: tl ->
         parse_words ({ w with value = parse_child word } :: acc) tl
-    | { Location_.value = `Space; _ } :: tl -> parse_words acc tl
+    | { Location_.value = `Space _; _ } :: tl -> parse_words acc tl
     | { location; _ } :: _ ->
         Error
           (Error.make "Only words are accepted when specifying children order"

--- a/src/model/semantics.ml
+++ b/src/model/semantics.ml
@@ -128,7 +128,7 @@ let leaf_inline_element :
  fun element ->
   match element with
   | { value = `Word _ | `Code_span _ | `Math_span _; _ } as element -> element
-  | { value = `Space _; _ } -> Location.same element `Space
+  | { value = `Space s; _ } -> Location.same element (`Space s)
   | { value = `Raw_markup (target, s); location } -> (
       match target with
       | Some invalid_target
@@ -144,6 +144,97 @@ let leaf_inline_element :
           Error.raise_warning (default_raw_markup_target_not_supported location);
           Location.same element (`Code_span s)
       | Some target -> Location.same element (`Raw_markup (target, s)))
+
+(* Rebuild [elt] only if the merge changed something *)
+let same elt content content' mk =
+  if content' == content then elt
+  else { elt with Location_.value = mk content' }
+
+(* Merge runs of [`Word]/[`Space] into one [`Word] *)
+let rec merge_ast_inline_elements elements =
+  let flush run acc =
+    match run with
+    | [] -> acc
+    | [ single ] -> single :: acc
+    | _ ->
+        let text_of { Location_.value; _ } =
+          match value with `Word w -> w | `Space s -> s | _ -> assert false
+        in
+        let value = `Word (String.concat ~sep:"" (List.rev_map text_of run)) in
+        let location =
+          Location.span (List.rev_map (fun e -> e.Location_.location) run)
+        in
+        { Location_.value; location } :: acc
+  in
+  let rec loop run acc = function
+    | [] -> List.rev (flush run acc)
+    | ({ Location_.value = `Word _ | `Space _; _ } as elt) :: tl ->
+        loop (elt :: run) acc tl
+    | elt :: tl -> loop [] (merge_ast_inline_element elt :: flush run acc) tl
+  in
+  let merged = loop [] [] elements in
+  let unchanged =
+    try List.for_all2 ( == ) merged elements with Invalid_argument _ -> false
+  in
+  if unchanged then elements else merged
+
+and merge_ast_inline_element elt =
+  let same content mk =
+    same elt content (merge_ast_inline_elements content) mk
+  in
+  match elt.Location_.value with
+  | `Styled (style, content) -> same content (fun c -> `Styled (style, c))
+  | `Reference (kind, target, content) ->
+      same content (fun c -> `Reference (kind, target, c))
+  | `Link (target, content) -> same content (fun c -> `Link (target, c))
+  | _ -> elt
+
+let rec merge_ast_nestable elt =
+  match elt.Location_.value with
+  | `Paragraph content ->
+      same elt content (merge_ast_inline_elements content) (fun c ->
+          `Paragraph c)
+  | `List (kind, weight, items) ->
+      let items = List.map (List.map merge_ast_nestable) items in
+      { elt with Location_.value = `List (kind, weight, items) }
+  | `Table ((grid, align), weight) ->
+      let grid =
+        List.map
+          (List.map (fun (cell, kind) ->
+               (List.map merge_ast_nestable cell, kind)))
+          grid
+      in
+      { elt with Location_.value = `Table ((grid, align), weight) }
+  | `Code_block _ | `Verbatim _ | `Modules _ | `Math_block _ | `Media _ -> elt
+
+(* Internal tags are skipped: they parse their payload word by word. *)
+let merge_ast (ast : Ast.t) : Ast.t =
+  let nestables = List.map merge_ast_nestable in
+  let tag : Ast.tag -> Ast.tag = function
+    | `Deprecated content -> `Deprecated (nestables content)
+    | `Param (s, content) -> `Param (s, nestables content)
+    | `Raise (s, content) -> `Raise (s, nestables content)
+    | `Return content -> `Return (nestables content)
+    | `See (kind, s, content) -> `See (kind, s, nestables content)
+    | `Before (s, content) -> `Before (s, nestables content)
+    | (`Author _ | `Since _ | `Version _ | #Ast.internal_tag) as t -> t
+  in
+  List.map
+    (fun elt ->
+      match elt.Location_.value with
+      | `Heading (level, label, content) ->
+          same elt content (merge_ast_inline_elements content) (fun c ->
+              `Heading (level, label, c))
+      | `Tag t -> { elt with Location_.value = `Tag (tag t) }
+      | #Ast.nestable_block_element as v ->
+          let nested = merge_ast_nestable { elt with Location_.value = v } in
+          if nested.Location_.value == v then elt
+          else
+            {
+              elt with
+              Location_.value = (nested.Location_.value :> Ast.block_element);
+            })
+    ast
 
 type surrounding =
   [ `Link of
@@ -352,6 +443,23 @@ let generate_heading_label : Comment.inline_element with_location list -> string
            Bytes.set result index c);
     Bytes.unsafe_to_string result
   in
+  (* Whitespace runs inside a merged [`Word] stood for a single [`Space], so
+     become a single hyphen. Code spans keep the per-character version. *)
+  let hyphenate_word_runs s =
+    let b = Buffer.create (String.length s) in
+    let in_ws = ref false in
+    Stdlib.String.iter
+      (fun c ->
+        match c with
+        | ' ' | '\t' | '\r' | '\n' ->
+            if not !in_ws then Buffer.add_char b '-';
+            in_ws := true
+        | c ->
+            Buffer.add_char b (Astring.Char.Ascii.lowercase c);
+            in_ws := false)
+      s;
+    Buffer.contents b
+  in
 
   let strip_locs li = List.map (fun ele -> ele.Location.value) li in
   (* Perhaps this should be done using a [Buffer.t]; we can switch to that as
@@ -361,8 +469,8 @@ let generate_heading_label : Comment.inline_element with_location list -> string
     | element :: more ->
         let anchor =
           match (element : Comment.inline_element) with
-          | `Space -> anchor ^ "-"
-          | `Word w -> anchor ^ Astring.String.Ascii.lowercase w
+          | `Space _ -> anchor ^ "-"
+          | `Word w -> anchor ^ hyphenate_word_runs w
           | `Code_span c | `Math_span c ->
               anchor ^ replace_spaces_with_hyphens_and_lowercase c
           | `Raw_markup _ ->
@@ -576,7 +684,7 @@ let handle_internal_tags (type a) tags : a handle_internal_tags -> a = function
       in
       let lines =
         let do_ parse loc els =
-          let els = nestable_block_elements els in
+          let els = List.map nestable_block_element els in
           match parse loc els with
           | Ok res -> Some res
           | Error e ->
@@ -603,7 +711,7 @@ let ast_to_comment ~internal_tags ~tags_allowed ~parent_of_sections
     (ast : Ast.t) alerts =
   Error.catch_warnings (fun () ->
       let status = { tags_allowed; parent_of_sections } in
-      let ast, tags = strip_internal_tags ast in
+      let ast, tags = strip_internal_tags (merge_ast ast) in
       let elts =
         top_level_block_elements status ast |> append_alerts_to_comment alerts
       in

--- a/src/model/semantics.mli
+++ b/src/model/semantics.mli
@@ -11,6 +11,11 @@ type sections_allowed = [ `All | `No_titles | `None ]
 type alerts =
   [ `Tag of [ `Alert of string * string option ] ] Location_.with_location list
 
+val merge_ast : Odoc_parser.Ast.t -> Odoc_parser.Ast.t
+(** Merge runs of [`Word]/[`Space] into single [`Word]s. Idempotent; the loader
+    applies it before its parse cache so that repeated comments share the merged
+    nodes. *)
+
 val ast_to_comment :
   internal_tags:'tags handle_internal_tags ->
   tags_allowed:bool ->

--- a/src/model_desc/comment_desc.ml
+++ b/src/model_desc/comment_desc.ml
@@ -6,7 +6,7 @@ open Paths_desc
 let ignore_loc x = x.Location_.value
 
 type general_inline_element =
-  [ `Space
+  [ `Space of string
   | `Word of string
   | `Code_span of string
   | `Math_span of string
@@ -72,7 +72,7 @@ let rec inline_element : general_inline_element t =
   in
   Variant
     (function
-    | `Space -> C0 "`Space"
+    | `Space s -> C ("`Space", s, string)
     | `Word x -> C ("`Word", x, string)
     | `Code_span x -> C ("`Code_span", x, string)
     | `Math_span x -> C ("`Math_span", x, string)

--- a/src/odoc/odoc_link.ml
+++ b/src/odoc/odoc_link.ml
@@ -27,11 +27,11 @@ let content_for_hidden_modules =
   let sentence =
     [
       `Word "This";
-      `Space;
+      `Space " ";
       `Word "module";
-      `Space;
+      `Space " ";
       `Word "is";
-      `Space;
+      `Space " ";
       `Word "hidden.";
     ]
   in

--- a/src/search/text.ml
+++ b/src/search/text.ml
@@ -72,7 +72,7 @@ module Of_comments = struct
     | `Code_span s -> s
     | `Word w -> w
     | `Math_span m -> m
-    | `Space -> " "
+    | `Space s -> s
     | `Reference (_, c) -> link_content c
     | `Link (_, c) -> link_content c
     | `Styled (_, b) -> inlines b

--- a/src/xref2/link.ml
+++ b/src/xref2/link.ml
@@ -234,7 +234,8 @@ let rec comment_inline_element_needs_resolving (x : Comment.inline_element) =
       List.exists
         (fun e -> comment_inline_element_needs_resolving e.Location_.value)
         xs
-  | `Space | `Word _ | `Code_span _ | `Math_span _ | `Raw_markup _ | `Link _ ->
+  | `Space _ | `Word _ | `Code_span _ | `Math_span _ | `Raw_markup _ | `Link _
+    ->
       false
 
 let rec comment_nestable_block_element_needs_resolving

--- a/test/frontmatter/frontmatter.t/run.t
+++ b/test/frontmatter/frontmatter.t/run.t
@@ -57,11 +57,7 @@ When there is one frontmatter, it is extracted from the content:
         },
         [
           {
-            "`Word": "One"
-          },
-          "`Space",
-          {
-            "`Word": "frontmatter"
+            "`Word": "One frontmatter"
           }
         ]
       ]
@@ -112,11 +108,7 @@ When there is more than one children order, we raise a warning and keep only the
         },
         [
           {
-            "`Word": "Two"
-          },
-          "`Space",
-          {
-            "`Word": "frontmatters"
+            "`Word": "Two frontmatters"
           }
         ]
       ]

--- a/test/frontmatter/short_title.t/run.t
+++ b/test/frontmatter/short_title.t/run.t
@@ -6,7 +6,7 @@ Normal use
   > EOF
   $ odoc compile --parent-id pkg --output-dir _odoc index.mld
   $ odoc_print _odoc/pkg/page-index.odoc | jq .frontmatter.short_title -c
-  {"Some":[{"`Word":"First"},"`Space",{"`Word":"try"}]}
+  {"Some":[{"`Word":"First"},{"`Space":" "},{"`Word":"try"}]}
 
 With inline content
 
@@ -16,7 +16,7 @@ With inline content
   > EOF
   $ odoc compile --parent-id pkg --output-dir _odoc index.mld
   $ odoc_print _odoc/pkg/page-index.odoc | jq .frontmatter.short_title -c
-  {"Some":[{"`Word":"with"},"`Space",{"`Code_span":"code"},"`Space",{"`Word":"and"},"`Space",{"`Styled":["`Emphasis",[{"`Word":"emphasized"}]]},"`Space",{"`Word":"content"}]}
+  {"Some":[{"`Word":"with"},{"`Space":" "},{"`Code_span":"code"},{"`Space":" "},{"`Word":"and"},{"`Space":" "},{"`Styled":["`Emphasis",[{"`Word":"emphasized"}]]},{"`Space":" "},{"`Word":"content"}]}
 
 With reference or link
 
@@ -26,7 +26,7 @@ With reference or link
   > EOF
   $ odoc compile --parent-id pkg --output-dir _odoc index.mld
   $ odoc_print _odoc/pkg/page-index.odoc | jq .frontmatter.short_title -c
-  {"Some":[{"`Word":"with"},"`Space","`Space",{"`Word":"and"},"`Space"]}
+  {"Some":[{"`Word":"with"},{"`Space":" "},{"`Space":" "},{"`Word":"and"},{"`Space":" "}]}
 
 With other block
 

--- a/test/generators/html/Alias-X.html
+++ b/test/generators/html/Alias-X.html
@@ -24,8 +24,9 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Module Foo__X documentation. This should appear in the documentation
-       for the alias to this module 'X'
+     <p>
+      Module Foo__X documentation. This should appear in the documentation
+      for the alias to this module 'X'
      </p>
     </div>
    </div>

--- a/test/generators/html/Bugs.html
+++ b/test/generators/html/Bugs.html
@@ -61,8 +61,8 @@
     </div>
     <div class="spec-doc">
      <p>Renders as 
-      <code>val repeat : 'a -&gt; 'b -&gt; 'c * 'd * 'e * 'f</code> before
-       https://github.com/ocaml/odoc/pull/1173
+      <code>val repeat : 'a -&gt; 'b -&gt; 'c * 'd * 'e * 'f</code>
+       before https://github.com/ocaml/odoc/pull/1173
      </p>
     </div>
    </div>

--- a/test/generators/html/Bugs_post_406.html
+++ b/test/generators/html/Bugs_post_406.html
@@ -13,8 +13,9 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Bugs_post_406</span></code></h1>
-   <p>Let-open in class types, https://github.com/ocaml/odoc/issues/543
-     This was added to the language in 4.06
+   <p>
+    Let-open in class types, https://github.com/ocaml/odoc/issues/543 This
+    was added to the language in 4.06
    </p>
   </header>
   <div class="odoc-content">

--- a/test/generators/html/Include2-Y_include_doc.html
+++ b/test/generators/html/Include2-Y_include_doc.html
@@ -18,8 +18,8 @@
   <div class="odoc-content">
    <div class="odoc-include">
     <div class="spec-doc">
-     <p>Doc attached to <code>include Y</code>. <code>Y</code>'s top-comment
-       shouldn't appear here.
+     <p>Doc attached to <code>include Y</code>. <code>Y</code>
+      's top-comment shouldn't appear here.
      </p>
     </div>
     <details open="open">

--- a/test/generators/html/Include2.html
+++ b/test/generators/html/Include2.html
@@ -79,8 +79,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>The <code>include Y</code> below should have the synopsis from
-       <code>Y</code>'s top-comment attached to it.
+     <p>The <code>include Y</code> below should have the synopsis from 
+      <code>Y</code>'s top-comment attached to it.
      </p>
     </div>
    </div>

--- a/test/generators/html/Include_sections.html
+++ b/test/generators/html/Include_sections.html
@@ -93,8 +93,9 @@
    <h4 id="something-1-bis_3">
     <a href="#something-1-bis_3" class="anchor"></a>Something 1-bis
    </h4><p>Some text.</p>
-   <p>And let's include it again, but without inlining it this time: 
-    the ToC shouldn't grow.
+   <p>
+    And let's include it again, but without inlining it this time: the ToC
+    shouldn't grow.
    </p>
    <div class="odoc-include">
     <details open="open">

--- a/test/generators/html/Markup.html
+++ b/test/generators/html/Markup.html
@@ -70,43 +70,47 @@
   </div>
   <div class="odoc-content">
    <h2 id="sections"><a href="#sections" class="anchor"></a>Sections</h2>
-   <p>Let's get these done first, because sections will be used to break
-     up the rest of this test.
+   <p>
+    Let's get these done first, because sections will be used to break up the
+    rest of this test.
    </p><p>Besides the section heading above, there are also</p>
    <h3 id="subsection-headings">
     <a href="#subsection-headings" class="anchor"></a>Subsection headings
    </h3><p>and</p>
    <h4 id="sub-subsection-headings">
-    <a href="#sub-subsection-headings" class="anchor"></a>Sub-subsection
-     headings
+    <a href="#sub-subsection-headings" class="anchor"></a>
+    Sub-subsection headings
    </h4>
-   <p>but odoc has banned deeper headings. There are also title headings,
-     but they are only allowed in mld files.
+   <p>
+    but odoc has banned deeper headings. There are also title headings, but
+    they are only allowed in mld files.
    </p><h4 id="anchors"><a href="#anchors" class="anchor"></a>Anchors</h4>
    <p>Sections can have attached 
-    <a href="#anchors" title="anchors">Anchors</a>, and it is possible
-     to <a href="#anchors" title="anchors">link</a> to them. Links to
-     section headers should not be set in source code style.
+    <a href="#anchors" title="anchors">Anchors</a>, and it is possible to 
+    <a href="#anchors" title="anchors">link</a>
+     to them. Links to section headers should not be set in source code
+    style.
    </p>
    <h5 id="paragraph"><a href="#paragraph" class="anchor"></a>Paragraph</h5>
    <p>Individual paragraphs can have a heading.</p>
    <h6 id="subparagraph"><a href="#subparagraph" class="anchor"></a>
     Subparagraph
    </h6>
-   <p>Parts of a longer paragraph that can be considered alone can also
-     have headings.
+   <p>
+    Parts of a longer paragraph that can be considered alone can also have
+    headings.
    </p><h2 id="styling"><a href="#styling" class="anchor"></a>Styling</h2>
    <p>This paragraph has some styled elements: <b>bold</b> and <i>italic</i>
     , <b><i>bold italic</i></b>, <em>emphasis</em>, 
     <em><em class="odd">emphasis</em> within emphasis</em>, 
     <b><i>bold italic</i></b>, super<sup>script</sup>, sub<sub>script</sub>
-    . The line spacing should be enough for superscripts and subscripts
-     not to look odd.
+    . The line spacing should be enough for superscripts and subscripts not
+    to look odd.
    </p>
    <p>Note: 
     <i>In italics <em>emphasis</em> is rendered as normal text while 
-     <em>emphasis <em class="odd">in</em> emphasis</em> is rendered in
-      italics.
+     <em>emphasis <em class="odd">in</em> emphasis</em>
+      is rendered in italics.
     </i> 
     <i>It also work the same in 
      <a href="#">links in italics with 
@@ -114,55 +118,57 @@
      </a>
     </i>
    </p>
-   <p><code>code</code> is a different kind of markup that doesn't allow
-     nested markup.
+   <p><code>code</code>
+     is a different kind of markup that doesn't allow nested markup.
    </p>
    <p>It's possible for two markup elements to appear <b>next</b> <i>to</i>
-     each other and have a space, and appear <b>next</b><i>to</i> each
-     other with no space. It doesn't matter <b>how</b> <i>much</i> space
-     it was in the source: in this sentence, it was two space characters.
-     And in this one, there is <b>a</b> <i>newline</i>.
+     each other and have a space, and appear <b>next</b><i>to</i>
+     each other with no space. It doesn't matter <b>how</b> <i>much</i>
+     space it was in the source: in this sentence, it was two space
+    characters. And in this one, there is <b>a</b> <i>newline</i>.
    </p>
-   <p>This is also true between <em>non-</em><code>code</code> markup
-     <em>and</em> <code>code</code>.
+   <p>This is also true between <em>non-</em><code>code</code> markup 
+    <em>and</em> <code>code</code>.
    </p>
-   <p>Code can appear <b>inside <code>other</code> markup</b>. Its display
-     shouldn't be affected.
+   <p>Code can appear <b>inside <code>other</code> markup</b>
+    . Its display shouldn't be affected.
    </p>
    <p>There is no differences between <code>a b</code> and <code>a b</code>.
    </p>
-   <p>Consecutive whitespaces not after a newline are conserved as they
-     are: <code>a   b</code>.
+   <p>Consecutive whitespaces not after a newline are conserved as they are: 
+    <code>a   b</code>.
    </p>
    <h2 id="links-and-references">
     <a href="#links-and-references" class="anchor"></a>Links and references
    </h2>
-   <p>This is a <a href="#">link</a>. It sends you to the top of this
-     page. Links can have markup inside them: <a href="#"><b>bold</b></a>
-    , <a href="#"><i>italics</i></a>, <a href="#"><em>emphasis</em></a>
-    , <a href="#">super<sup>script</sup></a>, 
+   <p>This is a <a href="#">link</a>
+    . It sends you to the top of this page. Links can have markup inside
+    them: <a href="#"><b>bold</b></a>, <a href="#"><i>italics</i></a>
+    , <a href="#"><em>emphasis</em></a>, 
+    <a href="#">super<sup>script</sup></a>, 
     <a href="#">sub<sub>script</sub></a>, and 
     <a href="#"><code>code</code></a>. Links can also be nested 
-    <em><a href="#">inside</a></em> markup. Links cannot be nested inside
-     each other. This link has no replacement text: <a href="#">#</a>
+    <em><a href="#">inside</a></em>
+     markup. Links cannot be nested inside each other. This link has no
+    replacement text: <a href="#">#</a>
     . The text is filled in by odoc. This is a shorthand link: 
     <a href="#">#</a>. The text is also filled in by odoc in this case.
    </p>
-   <p>This is a reference to <a href="#val-foo"><code>foo</code></a>.
-     References can have replacement text: 
-    <a href="#val-foo" title="foo">the value foo</a>. Except for the 
-    special lookup support, references are pretty much just like links.
-     The replacement text can have nested styles: 
+   <p>This is a reference to <a href="#val-foo"><code>foo</code></a>
+    . References can have replacement text: 
+    <a href="#val-foo" title="foo">the value foo</a>
+    . Except for the special lookup support, references are pretty much just
+    like links. The replacement text can have nested styles: 
     <a href="#val-foo" title="foo"><b>bold</b></a>, 
     <a href="#val-foo" title="foo"><i>italic</i></a>, 
     <a href="#val-foo" title="foo"><em>emphasis</em></a>, 
     <a href="#val-foo" title="foo">super<sup>script</sup></a>, 
     <a href="#val-foo" title="foo">sub<sub>script</sub></a>, and 
-    <a href="#val-foo" title="foo"><code>code</code></a>. It's also possible
-     to surround a reference in a style: 
-    <b><a href="#val-foo"><code>foo</code></a></b>. References can't 
-    be nested inside references, and links and references can't be nested
-     inside each other.
+    <a href="#val-foo" title="foo"><code>code</code></a>
+    . It's also possible to surround a reference in a style: 
+    <b><a href="#val-foo"><code>foo</code></a></b>
+    . References can't be nested inside references, and links and references
+    can't be nested inside each other.
    </p>
    <h2 id="preformatted-text">
     <a href="#preformatted-text" class="anchor"></a>Preformatted text
@@ -185,9 +191,9 @@
     <li>and the paragraphs in each list item support <em>styling</em>.</li>
    </ul><ol><li>This is a</li><li>shorthand numbered list.</li></ol>
    <ul>
-    <li>Shorthand list items can span multiple lines, however trying 
-     to put two paragraphs into a shorthand list item using a double 
-     line break
+    <li>
+     Shorthand list items can span multiple lines, however trying to put two
+     paragraphs into a shorthand list item using a double line break
     </li>
    </ul><p>just creates a paragraph outside the list.</p>
    <ul><li>Similarly, inserting a blank line between two list items</li></ul>
@@ -208,8 +214,8 @@
    <p>The parser supports any ASCII-compatible encoding.</p>
    <p>In particuλar UTF-8.</p>
    <h2 id="raw-html"><a href="#raw-html" class="anchor"></a>Raw HTML</h2>
-   <p>Raw HTML can be <input type="text" placeholder="inserted"> as inline
-     elements into sentences.
+   <p>Raw HTML can be <input type="text" placeholder="inserted">
+     as inline elements into sentences.
    </p>
    
     <blockquote>
@@ -257,27 +263,31 @@
     </tr>
     <tr>
      <td style="text-align:left">
-      <p>A much longer paragraph which will need to be wrapped and more
-        content and more content and some different content and we will
-        see what is does if we can see it
+      <p>
+       A much longer paragraph which will need to be wrapped and more content
+       and more content and some different content and we will see what is
+       does if we can see it
       </p>
      </td>
      <td style="text-align:center">
-      <p>B much longer paragraph which will need to be wrapped and more
-        content and more content and some different content and we will
-        see what is does if we can see it
+      <p>
+       B much longer paragraph which will need to be wrapped and more content
+       and more content and some different content and we will see what is
+       does if we can see it
       </p>
      </td>
      <td style="text-align:right">
-      <p>C much longer paragraph which will need to be wrapped and more
-        content and more content and some different content and we will
-        see what is does if we can see it
+      <p>
+       C much longer paragraph which will need to be wrapped and more content
+       and more content and some different content and we will see what is
+       does if we can see it
       </p>
      </td>
      <td>
-      <p>D much longer paragraph which will need to be wrapped and more
-        content and more content and some different content and we will
-        see what is does if we can see it
+      <p>
+       D much longer paragraph which will need to be wrapped and more content
+       and more content and some different content and we will see what is
+       does if we can see it
       </p>
      </td>
     </tr>

--- a/test/generators/html/Module.html
+++ b/test/generators/html/Module.html
@@ -21,8 +21,9 @@
      <code><span><span class="keyword">val</span> foo : unit</span></code>
     </div>
     <div class="spec-doc">
-     <p>The module needs at least one signature item, otherwise a bug
-       causes the compiler to drop the module comment (above). See 
+     <p>
+      The module needs at least one signature item, otherwise a bug causes
+      the compiler to drop the module comment (above). See 
       <a href="https://caml.inria.fr/mantis/view.php?id=7701">
        https://caml.inria.fr/mantis/view.php?id=7701
       </a>.

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigA.html
@@ -26,8 +26,8 @@
    </nav>
   </div>
   <div class="odoc-content">
-   <h4 id="subSig"><a href="#subSig" class="anchor"></a>A Labeled Section
-     Header Inside of a Signature
+   <h4 id="subSig"><a href="#subSig" class="anchor"></a>
+    A Labeled Section Header Inside of a Signature
    </h4>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-t">

--- a/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigB.html
+++ b/test/generators/html/Ocamlary-module-type-SuperSig-module-type-SubSigB.html
@@ -28,8 +28,8 @@
    </nav>
   </div>
   <div class="odoc-content">
-   <h4 id="subSig"><a href="#subSig" class="anchor"></a>Another Labeled
-     Section Header Inside of a Signature
+   <h4 id="subSig"><a href="#subSig" class="anchor"></a>
+    Another Labeled Section Header Inside of a Signature
    </h4>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-t">

--- a/test/generators/html/Ocamlary.html
+++ b/test/generators/html/Ocamlary.html
@@ -59,8 +59,8 @@
      <li><a href="#indexmodules">Trying the {!modules: ...} command.</a>
       <ul>
        <li>
-        <a href="#weirder-usages-involving-module-types">Weirder usages
-          involving module types
+        <a href="#weirder-usages-involving-module-types">
+         Weirder usages involving module types
         </a>
        </li>
       </ul>
@@ -75,8 +75,7 @@
    </nav>
   </div>
   <div class="odoc-content">
-   <p>You may find more information about this HTML documentation renderer
-     at 
+   <p>You may find more information about this HTML documentation renderer at 
     <a href="https://github.com/dsheets/ocamlary">github.com/dsheets/ocamlary
     </a>.
    </p><p>This is some verbatim text:</p><pre>verbatim</pre>
@@ -271,8 +270,8 @@
     </a> or 
     <a href="Ocamlary-module-type-SuperSig-module-type-EmptySig.html">
      <code>SuperSig.EmptySig</code>
-    </a>. Section <a href="#s9000" title="s9000">Section 9000</a> is 
-    also interesting. <a href="#emptySig" title="emptySig">EmptySig</a>
+    </a>. Section <a href="#s9000" title="s9000">Section 9000</a>
+     is also interesting. <a href="#emptySig" title="emptySig">EmptySig</a>
      is the section and 
     <a href="Ocamlary-module-type-EmptySig.html"><code>EmptySig</code></a>
      is the module signature.
@@ -296,8 +295,7 @@
     </div>
    </div><p>Some text before exception title.</p>
    <h4 id="basic-exception-stuff">
-    <a href="#basic-exception-stuff" class="anchor"></a>Basic exception
-     stuff
+    <a href="#basic-exception-stuff" class="anchor"></a>Basic exception stuff
    </h4><p>After exception title.</p>
    <div class="odoc-spec">
     <div class="spec exception anchored" id="exception-Kaboom">
@@ -343,8 +341,8 @@
      <p>
       <a href="Ocamlary-module-type-EmptySig.html"><code>EmptySig</code></a>
        is a module and 
-      <a href="#exception-EmptySig"><code>EmptySig</code></a> is this
-       exception.
+      <a href="#exception-EmptySig"><code>EmptySig</code></a>
+       is this exception.
      </p>
     </div>
    </div>
@@ -381,8 +379,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p><a href="#type-a_function"><code>a_function</code></a> is this
-       type and <a href="#val-a_function"><code>a_function</code></a>
+     <p><a href="#type-a_function"><code>a_function</code></a>
+       is this type and <a href="#val-a_function"><code>a_function</code></a>
        is the value below.
      </p>
     </div>
@@ -650,8 +648,7 @@
     </div>
    </div>
    <h4 id="advanced-module-stuff">
-    <a href="#advanced-module-stuff" class="anchor"></a>Advanced Module
-     Stuff
+    <a href="#advanced-module-stuff" class="anchor"></a>Advanced Module Stuff
    </h4>
    <div class="odoc-spec">
     <div class="spec module anchored" id="module-CollectionModule">
@@ -2713,14 +2710,16 @@
      </div>
     </details>
    </div>
-   <h2 id="indexmodules"><a href="#indexmodules" class="anchor"></a>Trying
-     the {!modules: ...} command.
+   <h2 id="indexmodules"><a href="#indexmodules" class="anchor"></a>
+    Trying the {!modules: ...} command.
    </h2>
-   <p>With ocamldoc, toplevel units will be linked and documented, while
-     submodules will behave as simple references.
+   <p>
+    With ocamldoc, toplevel units will be linked and documented, while
+    submodules will behave as simple references.
    </p>
-   <p>With odoc, everything should be resolved (and linked) but only 
-    toplevel units will be documented.
+   <p>
+    With odoc, everything should be resolved (and linked) but only toplevel
+    units will be documented.
    </p>
    <ul class="modules">
     <li><a href="Ocamlary-Dep1-X.html"><code>Dep1.X</code></a> </li>
@@ -2731,8 +2730,8 @@
     </li>
     <li><a href="#"><code>Ocamlary</code></a> 
      <span class="synopsis">This is an <i>interface</i> with <b>all</b>
-       of the <em>module system</em> features. This documentation 
-      demonstrates:
+       of the <em>module system</em>
+       features. This documentation demonstrates:
      </span>
     </li>
    </ul>
@@ -2748,8 +2747,8 @@
     </li><li><a href="Ocamlary-Dep4-X.html"><code>Dep4.X</code></a> </li>
    </ul>
    <h2 id="playing-with-@canonical-paths">
-    <a href="#playing-with-@canonical-paths" class="anchor"></a>Playing
-     with @canonical paths
+    <a href="#playing-with-@canonical-paths" class="anchor"></a>
+    Playing with @canonical paths
    </h2>
    <div class="odoc-spec">
     <div class="spec module anchored" id="module-CanonicalTest">
@@ -2793,13 +2792,13 @@
     </div><div class="spec-doc"><p>Let's imitate jst's layout.</p></div>
    </div>
    <h2 id="section-title-splicing">
-    <a href="#section-title-splicing" class="anchor"></a>Section title
-     splicing
+    <a href="#section-title-splicing" class="anchor"></a>
+    Section title splicing
    </h2><p>I can refer to</p>
    <ul>
     <li><code>{!section:indexmodules}</code> : 
-     <a href="#indexmodules" title="indexmodules">Trying the {!modules:
-       ...} command.
+     <a href="#indexmodules" title="indexmodules">
+      Trying the {!modules: ...} command.
      </a>
     </li>
     <li><code>{!aliases}</code> : 
@@ -2832,8 +2831,7 @@
     </li>
    </ul>
    <h2 id="new-reference-syntax">
-    <a href="#new-reference-syntax" class="anchor"></a>New reference 
-    syntax
+    <a href="#new-reference-syntax" class="anchor"></a>New reference syntax
    </h2>
    <div class="odoc-spec">
     <div class="spec module-type anchored" id="module-type-M">

--- a/test/generators/html/Oxcaml-Include_functor_argument_shapes-Aliased.html
+++ b/test/generators/html/Oxcaml-Include_functor_argument_shapes-Aliased.html
@@ -21,8 +21,9 @@
    <h1>Module 
     <code><span>Include_functor_argument_shapes.Aliased</span></code>
    </h1>
-   <p>The input module itself. It should contain everything from the 
-    top level module
+   <p>
+    The input module itself. It should contain everything from the top level
+    module
    </p>
   </header>
   <div class="odoc-content">
@@ -41,9 +42,10 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Everything the expansion of the functor can inherit from its 
-      argument: types, including parameterised and anonymously parameterised
-       ones, submodules, and module types.
+     <p>
+      Everything the expansion of the functor can inherit from its argument:
+      types, including parameterised and anonymously parameterised ones,
+      submodules, and module types.
      </p>
     </div>
    </div>

--- a/test/generators/html/Oxcaml-Include_functor_argument_shapes-Make.html
+++ b/test/generators/html/Oxcaml-Include_functor_argument_shapes-Make.html
@@ -62,8 +62,9 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>No parameters, so the alias odoc puts in the synthetic module
-       is a bare <code>type t = t</code>.
+     <p>
+      No parameters, so the alias odoc puts in the synthetic module is a bare 
+      <code>type t = t</code>.
      </p>
     </div>
    </div>
@@ -102,9 +103,9 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>An anonymous parameter: <code>_</code> gives the alias no name
-       to mention on the right, so one is invented, as 
-      <code>type 'a0 anon = 'a0 anon</code>.
+     <p>An anonymous parameter: <code>_</code>
+       gives the alias no name to mention on the right, so one is invented,
+      as <code>type 'a0 anon = 'a0 anon</code>.
      </p>
     </div>
    </div>
@@ -202,8 +203,9 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>The input module itself. It should contain everything from the
-       top level module
+     <p>
+      The input module itself. It should contain everything from the top
+      level module
      </p>
     </div>
    </div>

--- a/test/generators/html/Oxcaml-Include_functor_argument_shapes-module-type-Arg.html
+++ b/test/generators/html/Oxcaml-Include_functor_argument_shapes-module-type-Arg.html
@@ -20,9 +20,10 @@
    <h1>Module type 
     <code><span>Include_functor_argument_shapes.Arg</span></code>
    </h1>
-   <p>Everything the expansion of the functor can inherit from its argument:
-     types, including parameterised and anonymously parameterised ones,
-     submodules, and module types.
+   <p>
+    Everything the expansion of the functor can inherit from its argument:
+    types, including parameterised and anonymously parameterised ones,
+    submodules, and module types.
    </p>
   </header>
   <div class="odoc-content">

--- a/test/generators/html/Oxcaml-Include_functor_argument_shapes.html
+++ b/test/generators/html/Oxcaml-Include_functor_argument_shapes.html
@@ -36,9 +36,10 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Everything the expansion of the functor can inherit from its 
-      argument: types, including parameterised and anonymously parameterised
-       ones, submodules, and module types.
+     <p>
+      Everything the expansion of the functor can inherit from its argument:
+      types, including parameterised and anonymously parameterised ones,
+      submodules, and module types.
      </p>
     </div>
    </div>
@@ -178,8 +179,9 @@
        </code>
       </div>
       <div class="spec-doc">
-       <p>No parameters, so the alias odoc puts in the synthetic module
-         is a bare <code>type t = t</code>.
+       <p>
+        No parameters, so the alias odoc puts in the synthetic module is a
+        bare <code>type t = t</code>.
        </p>
       </div>
      </div>
@@ -204,9 +206,9 @@
        </code>
       </div>
       <div class="spec-doc">
-       <p>An anonymous parameter: <code>_</code> gives the alias no name
-         to mention on the right, so one is invented, as 
-        <code>type 'a0 anon = 'a0 anon</code>.
+       <p>An anonymous parameter: <code>_</code>
+         gives the alias no name to mention on the right, so one is invented,
+        as <code>type 'a0 anon = 'a0 anon</code>.
        </p>
       </div>
      </div>
@@ -294,8 +296,9 @@
        </code>
       </div>
       <div class="spec-doc">
-       <p>The input module itself. It should contain everything from 
-        the top level module
+       <p>
+        The input module itself. It should contain everything from the top
+        level module
        </p>
       </div>
      </div>

--- a/test/generators/html/Oxcaml-Include_functor_desugared-Make.html
+++ b/test/generators/html/Oxcaml-Include_functor_desugared-Make.html
@@ -20,8 +20,8 @@
    <p>This module is the desugared version of 
     <a href="Oxcaml-Include_functor.html"><code>Include_functor</code></a>
     : the synthetic module aliases the preceding items rather than copying
-     them, so that the types the functor inherits from its argument resolve
-     back to them.
+    them, so that the types the functor inherits from its argument resolve
+    back to them.
    </p>
   </header>
   <div class="odoc-tocs">

--- a/test/generators/html/Oxcaml-Include_functor_desugared.html
+++ b/test/generators/html/Oxcaml-Include_functor_desugared.html
@@ -35,9 +35,9 @@
     <div class="spec-doc">
      <p>This module is the desugared version of 
       <a href="Oxcaml-Include_functor.html"><code>Include_functor</code></a>
-      : the synthetic module aliases the preceding items rather than 
-      copying them, so that the types the functor inherits from its argument
-       resolve back to them.
+      : the synthetic module aliases the preceding items rather than copying
+      them, so that the types the functor inherits from its argument resolve
+      back to them.
      </p>
     </div>
    </div>

--- a/test/generators/html/Oxcaml-Include_functor_not_last-Make.html
+++ b/test/generators/html/Oxcaml-Include_functor_not_last-Make.html
@@ -16,8 +16,8 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Include_functor_not_last.Make</span></code></h1>
-   <p>An <code>include functor</code> that is not the last item of the
-     signature.
+   <p>An <code>include functor</code>
+     that is not the last item of the signature.
    </p>
   </header>
   <div class="odoc-tocs">

--- a/test/generators/html/Oxcaml-Include_functor_not_last.html
+++ b/test/generators/html/Oxcaml-Include_functor_not_last.html
@@ -33,8 +33,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>An <code>include functor</code> that is not the last item of 
-      the signature.
+     <p>An <code>include functor</code>
+       that is not the last item of the signature.
      </p>
     </div>
    </div>

--- a/test/generators/html/Oxcaml-M1.html
+++ b/test/generators/html/Oxcaml-M1.html
@@ -69,8 +69,8 @@
      </code>
     </div>
    </div>
-   <p><code>uncontended</code> and <code>nonportable</code> are the defaults
-     (not rendered).
+   <p><code>uncontended</code> and <code>nonportable</code>
+     are the defaults (not rendered).
    </p>
    <div class="odoc-spec">
     <div class="spec value anchored" id="val-uncontended">

--- a/test/generators/html/Oxcaml-M2.html
+++ b/test/generators/html/Oxcaml-M2.html
@@ -14,8 +14,9 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Oxcaml.M2</span></code></h1>
-   <p>Module with <code>portable</code> modality. The modality is applied
-     to all value members of <code>M2</code>.
+   <p>Module with <code>portable</code>
+     modality. The modality is applied to all value members of 
+    <code>M2</code>.
    </p>
   </header>
   <div class="odoc-content">

--- a/test/generators/html/Oxcaml-M3.html
+++ b/test/generators/html/Oxcaml-M3.html
@@ -14,8 +14,9 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Oxcaml.M3</span></code></h1>
-   <p><code>contended</code> modality applied to all definitions in the
-     module, except the ones which have already specified this axis.
+   <p><code>contended</code>
+     modality applied to all definitions in the module, except the ones which
+    have already specified this axis.
    </p>
   </header>
   <div class="odoc-content">

--- a/test/generators/html/Oxcaml-Multiple_include_functors-First.html
+++ b/test/generators/html/Oxcaml-Multiple_include_functors-First.html
@@ -17,8 +17,8 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Multiple_include_functors.First</span></code></h1>
-   <p>Two <code>include functor</code>s in the same signature, with an
-     item defined between them.
+   <p>Two <code>include functor</code>
+    s in the same signature, with an item defined between them.
    </p>
   </header>
   <div class="odoc-tocs">

--- a/test/generators/html/Oxcaml-Multiple_include_functors.html
+++ b/test/generators/html/Oxcaml-Multiple_include_functors.html
@@ -33,8 +33,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Two <code>include functor</code>s in the same signature, with
-       an item defined between them.
+     <p>Two <code>include functor</code>
+      s in the same signature, with an item defined between them.
      </p>
     </div>
    </div>

--- a/test/generators/html/Oxcaml-No_include_functor-Make.html
+++ b/test/generators/html/Oxcaml-No_include_functor-Make.html
@@ -16,8 +16,8 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>No_include_functor.Make</span></code></h1>
-   <p>Module without any <code>include functor</code> features, this 
-    is how things are done in plain OCaml at the moment.
+   <p>Module without any <code>include functor</code>
+     features, this is how things are done in plain OCaml at the moment.
    </p>
   </header>
   <div class="odoc-tocs">

--- a/test/generators/html/Oxcaml-No_include_functor.html
+++ b/test/generators/html/Oxcaml-No_include_functor.html
@@ -32,8 +32,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Module without any <code>include functor</code> features, this
-       is how things are done in plain OCaml at the moment.
+     <p>Module without any <code>include functor</code>
+       features, this is how things are done in plain OCaml at the moment.
      </p>
     </div>
    </div>

--- a/test/generators/html/Oxcaml-module-type-S.html
+++ b/test/generators/html/Oxcaml-module-type-S.html
@@ -68,8 +68,8 @@
      </code>
     </div>
    </div>
-   <p><code>uncontended</code> and <code>nonportable</code> are the defaults
-     (not rendered).
+   <p><code>uncontended</code> and <code>nonportable</code>
+     are the defaults (not rendered).
    </p>
    <div class="odoc-spec">
     <div class="spec value anchored" id="val-uncontended">

--- a/test/generators/html/Oxcaml.html
+++ b/test/generators/html/Oxcaml.html
@@ -2265,8 +2265,8 @@
     </div>
    </div>
    <h2 id="include-functor-on-signatures">
-    <a href="#include-functor-on-signatures" class="anchor"></a>Include
-     functor on signatures
+    <a href="#include-functor-on-signatures" class="anchor"></a>
+    Include functor on signatures
    </h2>
    <div class="odoc-spec">
     <div class="spec module anchored" id="module-No_include_functor">

--- a/test/generators/html/Oxcaml.html
+++ b/test/generators/html/Oxcaml.html
@@ -19,55 +19,55 @@
     <ul><li><a href="#layouts">Layouts</a></li>
      <li><a href="#kind-abbreviations">Kind abbreviations</a></li>
      <li>
-      <a href="#kind-annotations-with-modalities">Kind annotations with
-        modalities
+      <a href="#kind-annotations-with-modalities">
+       Kind annotations with modalities
       </a>
      </li>
      <li>
-      <a href="#kind-annotations-on-parameterized-types">Kind annotations
-        on parameterized types
+      <a href="#kind-annotations-on-parameterized-types">
+       Kind annotations on parameterized types
       </a>
      </li>
      <li>
-      <a href="#kind-annotations-with-with-constraints">Kind annotations
-        with <code>with</code> constraints
+      <a href="#kind-annotations-with-with-constraints">Kind annotations with 
+       <code>with</code> constraints
       </a>
      </li>
      <li>
-      <a href="#kind-annotations-on-type-aliases">Kind annotations on
-        type aliases
+      <a href="#kind-annotations-on-type-aliases">
+       Kind annotations on type aliases
       </a>
      </li>
      <li>
-      <a href="#kind-constrained-polymorphism-in-values">Kind-constrained
-        polymorphism in values
+      <a href="#kind-constrained-polymorphism-in-values">
+       Kind-constrained polymorphism in values
       </a>
      </li>
      <li>
-      <a href="#parenthesization-of-product-kinds">Parenthesization of
-        product kinds
+      <a href="#parenthesization-of-product-kinds">
+       Parenthesization of product kinds
       </a>
      </li><li><a href="#kind-abbreviations_2">Kind abbreviations</a></li>
      <li><a href="#zero-alloc">Zero alloc</a></li>
      <li><a href="#modalities">Modalities</a></li>
      <li>
-      <a href="#multiple-modalities-on-a-field">Multiple modalities on
-        a field
+      <a href="#multiple-modalities-on-a-field">
+       Multiple modalities on a field
       </a>
      </li>
      <li>
-      <a href="#modalities-on-tuple-and-function-fields">Modalities on
-        tuple and function fields
+      <a href="#modalities-on-tuple-and-function-fields">
+       Modalities on tuple and function fields
       </a>
      </li>
      <li>
-      <a href="#modalities-on-constructor-arguments">Modalities on 
-       constructor arguments
+      <a href="#modalities-on-constructor-arguments">
+       Modalities on constructor arguments
       </a>
       <ul><li><a href="#modalities-on-values">Modalities on values</a></li>
        <li>
-        <a href="#modalities-on-module-declarations">Modalities on module
-          declarations
+        <a href="#modalities-on-module-declarations">
+         Modalities on module declarations
         </a>
        </li>
       </ul>
@@ -222,8 +222,8 @@
      <code><span><span class="keyword">type</span> t_value</span></code>
     </div>
     <div class="spec-doc">
-     <p><code>value</code> is the default kind, so the annotation is 
-      not rendered.
+     <p><code>value</code>
+       is the default kind, so the annotation is not rendered.
      </p>
     </div>
    </div>
@@ -283,8 +283,8 @@
     </div>
    </div>
    <h2 id="kind-annotations-with-modalities">
-    <a href="#kind-annotations-with-modalities" class="anchor"></a>Kind
-     annotations with modalities
+    <a href="#kind-annotations-with-modalities" class="anchor"></a>
+    Kind annotations with modalities
    </h2>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-t_portable">
@@ -443,9 +443,9 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>A <code>with</code> constraint whose right-hand side is a 
-      parameterized type constructor (as found in <code>base</code>'s
-       <code>Map</code> module).
+     <p>A <code>with</code>
+       constraint whose right-hand side is a parameterized type constructor
+      (as found in <code>base</code>'s <code>Map</code> module).
      </p>
     </div>
    </div>
@@ -460,8 +460,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>A <code>with</code> constraint whose right-hand side applies 
-      a type constructor.
+     <p>A <code>with</code>
+       constraint whose right-hand side applies a type constructor.
      </p>
     </div>
    </div>
@@ -478,8 +478,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>A <code>with</code> constraint whose right-hand side is an arrow
-       type.
+     <p>A <code>with</code>
+       constraint whose right-hand side is an arrow type.
      </p>
     </div>
    </div>
@@ -497,8 +497,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>A <code>with</code> constraint whose right-hand side is an arrow
-       type carrying a mode.
+     <p>A <code>with</code>
+       constraint whose right-hand side is an arrow type carrying a mode.
      </p>
     </div>
    </div>
@@ -546,8 +546,9 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>A <code>with</code> constraint referring to a type through a 
-      module path (<code>M.t</code>).
+     <p>A <code>with</code>
+       constraint referring to a type through a module path (<code>M.t</code>
+      ).
      </p>
     </div>
    </div>
@@ -607,8 +608,9 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>A <code>with</code> constraint referring to a type through a 
-      functor application (<code>F(X).t</code>).
+     <p>A <code>with</code>
+       constraint referring to a type through a functor application (
+      <code>F(X).t</code>).
      </p>
     </div>
    </div>
@@ -625,8 +627,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>A <code>with</code> constraint whose right-hand side is a polymorphic
-       variant.
+     <p>A <code>with</code>
+       constraint whose right-hand side is a polymorphic variant.
      </p>
     </div>
    </div>
@@ -641,14 +643,14 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>A <code>with</code> constraint whose right-hand side is an object
-       type.
+     <p>A <code>with</code>
+       constraint whose right-hand side is an object type.
      </p>
     </div>
    </div>
    <h2 id="kind-annotations-on-type-aliases">
-    <a href="#kind-annotations-on-type-aliases" class="anchor"></a>Kind
-     annotations on type aliases
+    <a href="#kind-annotations-on-type-aliases" class="anchor"></a>
+    Kind annotations on type aliases
    </h2>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-t_alias">
@@ -773,8 +775,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Zero allocation bindings have an extension attribute attached.
-       See 
+     <p>
+      Zero allocation bindings have an extension attribute attached. See
       https://oxcaml.org/documentation/miscellaneous-extensions/zero_alloc_check/
      </p>
     </div>
@@ -1082,8 +1084,8 @@
     </div>
    </div>
    <h2 id="multiple-modalities-on-a-field">
-    <a href="#multiple-modalities-on-a-field" class="anchor"></a>Multiple
-     modalities on a field
+    <a href="#multiple-modalities-on-a-field" class="anchor"></a>
+    Multiple modalities on a field
    </h2>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-modalities_multi">
@@ -1358,8 +1360,7 @@
     </div>
    </div>
    <h3 id="modalities-on-values">
-    <a href="#modalities-on-values" class="anchor"></a>Modalities on 
-    values
+    <a href="#modalities-on-values" class="anchor"></a>Modalities on values
    </h3>
    <div class="odoc-spec">
     <div class="spec value anchored" id="val-portable_fn">
@@ -1414,8 +1415,9 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Module with <code>portable</code> modality. The modality is applied
-       to all value members of <code>M2</code>.
+     <p>Module with <code>portable</code>
+       modality. The modality is applied to all value members of 
+      <code>M2</code>.
      </p>
     </div>
    </div>
@@ -1432,9 +1434,9 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p><code>contended</code> modality applied to all definitions in
-       the module, except the ones which have already specified this 
-      axis.
+     <p><code>contended</code>
+       modality applied to all definitions in the module, except the ones
+      which have already specified this axis.
      </p>
     </div>
    </div><h2 id="modes"><a href="#modes" class="anchor"></a>Modes</h2>
@@ -1494,8 +1496,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Same as <code>mode_multi</code>, to show that modes order is 
-      normalized.
+     <p>Same as <code>mode_multi</code>
+      , to show that modes order is normalized.
      </p>
     </div>
    </div>
@@ -1557,20 +1559,22 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Mode on a result that is itself an arrow. The arrow must be 
-      parenthesized so the mode does not appear to bind to the inner 
-      return type.
+     <p>
+      Mode on a result that is itself an arrow. The arrow must be
+      parenthesized so the mode does not appear to bind to the inner return
+      type.
      </p>
     </div>
    </div>
    <h3 id="curry-implied-result-modes">
-    <a href="#curry-implied-result-modes" class="anchor"></a>Curry-implied
-     result modes
+    <a href="#curry-implied-result-modes" class="anchor"></a>
+    Curry-implied result modes
    </h3>
-   <p>Closing over an argument constrains the partial-application closure
-     across several axes, not just locality. When the result mode is 
-    the one currying implies from the argument, it is suppressed (as 
-    the compiler does).
+   <p>
+    Closing over an argument constrains the partial-application closure
+    across several axes, not just locality. When the result mode is the one
+    currying implies from the argument, it is suppressed (as the compiler
+    does).
    </p>
    <div class="odoc-spec">
     <div class="spec value anchored" id="val-curry_once">
@@ -1586,8 +1590,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p><code>once</code> argument: the implied <code>once</code> result
-       mode is suppressed.
+     <p><code>once</code> argument: the implied <code>once</code>
+       result mode is suppressed.
      </p>
     </div>
    </div>
@@ -1605,8 +1609,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p><code>portable</code> argument: the implied result mode is 
-      suppressed.
+     <p><code>portable</code>
+       argument: the implied result mode is suppressed.
      </p>
     </div>
    </div>
@@ -1624,18 +1628,19 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p><code>contended</code> argument: the implied result mode is 
-      suppressed.
+     <p><code>contended</code>
+       argument: the implied result mode is suppressed.
      </p>
     </div>
    </div>
    <h3 id="result-modes-that-are-kept">
-    <a href="#result-modes-that-are-kept" class="anchor"></a>Result modes
-     that are kept
+    <a href="#result-modes-that-are-kept" class="anchor"></a>
+    Result modes that are kept
    </h3>
-   <p>A result mode is only suppressed when it is exactly the one currying
-     implies. An explicit mode on a different axis is kept (and the arrow
-     result is parenthesized).
+   <p>
+    A result mode is only suppressed when it is exactly the one currying
+    implies. An explicit mode on a different axis is kept (and the arrow
+    result is parenthesized).
    </p>
    <div class="odoc-spec">
     <div class="spec value anchored" id="val-keep_portable">
@@ -1686,8 +1691,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>The curry-implied <code>once</code> is suppressed, but the explicit
-       <code>portable</code> is kept.
+     <p>The curry-implied <code>once</code> is suppressed, but the explicit 
+      <code>portable</code> is kept.
      </p>
     </div>
    </div>
@@ -1706,8 +1711,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>The curry-implied <code>local</code> is suppressed, but the explicit
-       <code>portable</code> is kept.
+     <p>The curry-implied <code>local</code> is suppressed, but the explicit 
+      <code>portable</code> is kept.
      </p>
     </div>
    </div>
@@ -1727,9 +1732,9 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>The <code>nonportable</code> argument mode is the default and
-       dropped, while the explicit <code>portable</code> result, not 
-      implied by currying, is kept.
+     <p>The <code>nonportable</code>
+       argument mode is the default and dropped, while the explicit 
+      <code>portable</code> result, not implied by currying, is kept.
      </p>
     </div>
    </div>
@@ -1903,8 +1908,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Fork mode (identity on a non-<code>local</code> argument, not
-       rendered).
+     <p>Fork mode (identity on a non-<code>local</code>
+       argument, not rendered).
      </p>
     </div>
    </div>
@@ -1970,8 +1975,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Statefulness mode (identity when <code>portability</code> is 
-      at its default, not rendered).
+     <p>Statefulness mode (identity when <code>portability</code>
+       is at its default, not rendered).
      </p>
     </div>
    </div>
@@ -2031,11 +2036,12 @@
     <div class="spec-doc"><p>Staticity mode (legacy, not rendered).</p></div>
    </div>
    <h3 id="cross-axis-suppression">
-    <a href="#cross-axis-suppression" class="anchor"></a>Cross-axis 
-    suppression
+    <a href="#cross-axis-suppression" class="anchor"></a>
+    Cross-axis suppression
    </h3>
-   <p>Some axes have a default value that is implied by another axis;
-     the implied value is suppressed when rendering.
+   <p>
+    Some axes have a default value that is implied by another axis; the
+    implied value is suppressed when rendering.
    </p>
    <div class="odoc-spec">
     <div class="spec value anchored" id="val-mode_local_yielding">
@@ -2048,8 +2054,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p><code>yielding</code> is the default for <code>local</code>, 
-      so it is not rendered.
+     <p><code>yielding</code> is the default for <code>local</code>
+      , so it is not rendered.
      </p>
     </div>
    </div>
@@ -2135,8 +2141,8 @@
     </div>
    </div>
    <h3 id="modes-in-type-definitions">
-    <a href="#modes-in-type-definitions" class="anchor"></a>Modes in 
-    type definitions
+    <a href="#modes-in-type-definitions" class="anchor"></a>
+    Modes in type definitions
    </h3>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-mode_alias">

--- a/test/generators/html/Oxcaml_impl-Anonymous_functor.html
+++ b/test/generators/html/Oxcaml_impl-Anonymous_functor.html
@@ -22,9 +22,10 @@
      <code><span><span class="keyword">type</span> t</span></code>
     </div>
     <div class="spec-doc">
-     <p>The functor is defined inline, so there is no path for odoc to
-       apply: it has to bind the functor to a module first, as it does
-       for every <code>include functor</code> in a signature.
+     <p>
+      The functor is defined inline, so there is no path for odoc to apply:
+      it has to bind the functor to a module first, as it does for every 
+      <code>include functor</code> in a signature.
      </p>
     </div>
    </div>

--- a/test/generators/html/Oxcaml_impl-Include_functor-Make.html
+++ b/test/generators/html/Oxcaml_impl-Include_functor-Make.html
@@ -16,10 +16,10 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Include_functor.Make</span></code></h1>
-   <p>This module demonstrates the <code>include functor</code> 
-    functionality. <code>Make</code> uses its argument, so 
-    <code>included</code> has to come out equal to <code>t</code> rather
-     than abstract.
+   <p>This module demonstrates the <code>include functor</code>
+     functionality. <code>Make</code> uses its argument, so 
+    <code>included</code> has to come out equal to <code>t</code>
+     rather than abstract.
    </p>
   </header>
   <div class="odoc-tocs">

--- a/test/generators/html/Oxcaml_impl-Include_functor.html
+++ b/test/generators/html/Oxcaml_impl-Include_functor.html
@@ -32,10 +32,10 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>This module demonstrates the <code>include functor</code> 
-      functionality. <code>Make</code> uses its argument, so 
-      <code>included</code> has to come out equal to <code>t</code> rather
-       than abstract.
+     <p>This module demonstrates the <code>include functor</code>
+       functionality. <code>Make</code> uses its argument, so 
+      <code>included</code> has to come out equal to <code>t</code>
+       rather than abstract.
      </p>
     </div>
    </div>

--- a/test/generators/html/Oxcaml_impl-Include_functor_not_last-Make.html
+++ b/test/generators/html/Oxcaml_impl-Include_functor_not_last-Make.html
@@ -18,8 +18,8 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Include_functor_not_last.Make</span></code></h1>
-   <p>An <code>include functor</code> that is not the last item of the
-     structure.
+   <p>An <code>include functor</code>
+     that is not the last item of the structure.
    </p>
   </header>
   <div class="odoc-tocs">

--- a/test/generators/html/Oxcaml_impl-Include_functor_not_last.html
+++ b/test/generators/html/Oxcaml_impl-Include_functor_not_last.html
@@ -36,8 +36,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>An <code>include functor</code> that is not the last item of 
-      the structure.
+     <p>An <code>include functor</code>
+       that is not the last item of the structure.
      </p>
     </div>
    </div>

--- a/test/generators/html/Oxcaml_impl-Multiple_include_functors-First.html
+++ b/test/generators/html/Oxcaml_impl-Multiple_include_functors-First.html
@@ -18,8 +18,8 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Multiple_include_functors.First</span></code></h1>
-   <p>Two <code>include functor</code>s in the same structure, with an
-     item defined between them.
+   <p>Two <code>include functor</code>
+    s in the same structure, with an item defined between them.
    </p>
   </header>
   <div class="odoc-tocs">

--- a/test/generators/html/Oxcaml_impl-Multiple_include_functors.html
+++ b/test/generators/html/Oxcaml_impl-Multiple_include_functors.html
@@ -37,8 +37,8 @@
      </code>
     </div>
     <div class="spec-doc">
-     <p>Two <code>include functor</code>s in the same structure, with
-       an item defined between them.
+     <p>Two <code>include functor</code>
+      s in the same structure, with an item defined between them.
      </p>
     </div>
    </div>

--- a/test/generators/html/Oxcaml_impl.html
+++ b/test/generators/html/Oxcaml_impl.html
@@ -24,8 +24,8 @@
         </a>
        </li>
        <li>
-        <a href="#modalities-on-constructor-arguments">Modalities on 
-         constructor arguments
+        <a href="#modalities-on-constructor-arguments">
+         Modalities on constructor arguments
         </a>
        </li>
       </ul>
@@ -92,8 +92,8 @@
    <h2 id="modalities"><a href="#modalities" class="anchor"></a>Modalities
    </h2>
    <h3 id="modalities-on-record-fields">
-    <a href="#modalities-on-record-fields" class="anchor"></a>Modalities
-     on record fields
+    <a href="#modalities-on-record-fields" class="anchor"></a>
+    Modalities on record fields
    </h3>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-modalities_record">
@@ -200,8 +200,8 @@
     </div>
    </div><h2 id="modes"><a href="#modes" class="anchor"></a>Modes</h2>
    <h3 id="modes-in-type-definitions">
-    <a href="#modes-in-type-definitions" class="anchor"></a>Modes in 
-    type definitions
+    <a href="#modes-in-type-definitions" class="anchor"></a>
+    Modes in type definitions
    </h3>
    <div class="odoc-spec">
     <div class="spec type anchored" id="type-mode_alias">

--- a/test/generators/html/Oxcaml_impl.html
+++ b/test/generators/html/Oxcaml_impl.html
@@ -323,8 +323,8 @@
     <div class="spec-doc"><p>Multiple modes on argument and return.</p></div>
    </div>
    <h2 id="include-functor-on-structures">
-    <a href="#include-functor-on-structures" class="anchor"></a>Include
-     functor on structures
+    <a href="#include-functor-on-structures" class="anchor"></a>
+    Include functor on structures
    </h2>
    <div class="odoc-spec">
     <div class="spec module anchored" id="module-Include_functor">

--- a/test/generators/html/Section.html
+++ b/test/generators/html/Section.html
@@ -13,8 +13,8 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Section</span></code></h1>
-   <p>This is the module comment. Eventually, sections won't be allowed
-     in it.
+   <p>
+    This is the module comment. Eventually, sections won't be allowed in it.
    </p>
   </header>
   <div class="odoc-tocs">
@@ -27,8 +27,8 @@
      <li><a href="#within-a-comment">within a comment</a>
       <ul>
        <li>
-        <a href="#and-one-with-a-nested-section">and one with a nested
-          section
+        <a href="#and-one-with-a-nested-section">
+         and one with a nested section
         </a>
        </li>
       </ul>
@@ -64,16 +64,17 @@
     within a comment
    </h2>
    <h3 id="and-one-with-a-nested-section">
-    <a href="#and-one-with-a-nested-section" class="anchor"></a>and one
-     with a nested section
+    <a href="#and-one-with-a-nested-section" class="anchor"></a>
+    and one with a nested section
    </h3>
    <h2 id="this-section-title-has-markup">
     <a href="#this-section-title-has-markup" class="anchor"></a><em>This</em>
      <code>section</code> <b>title</b> <sub>has</sub> <sup>markup</sup>
    </h2>
-   <p>But links are impossible thanks to the parser, so we never have
-     trouble rendering a section title in a table of contents - no link
-     will be nested inside another link.
+   <p>
+    But links are impossible thanks to the parser, so we never have trouble
+    rendering a section title in a table of contents - no link will be nested
+    inside another link.
    </p>
   </div>
  </body>

--- a/test/generators/html/Stop.html
+++ b/test/generators/html/Stop.html
@@ -22,16 +22,18 @@
      <code><span><span class="keyword">val</span> foo : int</span></code>
     </div><div class="spec-doc"><p>This is normal commented text.</p></div>
    </div>
-   <p>The next value is <code>bar</code>, and it should be missing from
-     the documentation. There is also an entire module, <code>M</code>
-    , which should also be hidden. It contains a nested stop comment,
-     but that stop comment should not turn documentation back on in this
-     outer module, because stop comments respect scope.
+   <p>The next value is <code>bar</code>
+    , and it should be missing from the documentation. There is also an
+    entire module, <code>M</code>
+    , which should also be hidden. It contains a nested stop comment, but
+    that stop comment should not turn documentation back on in this outer
+    module, because stop comments respect scope.
    </p><p>Documentation is on again.</p>
-   <p>Now, we have a nested module, and it has a stop comment between
-     its two items. We want to see that the first item is displayed, 
-    but the second is missing, and the stop comment disables documenation
-     only in that module, and not in this outer module.
+   <p>
+    Now, we have a nested module, and it has a stop comment between its two
+    items. We want to see that the first item is displayed, but the second is
+    missing, and the stop comment disables documenation only in that module,
+    and not in this outer module.
    </p>
    <div class="odoc-spec">
     <div class="spec module anchored" id="module-N">
@@ -52,9 +54,9 @@
     </div>
    </div>
    <p>The first comment can also be a stop-comment. The test case 
-    <code>stop_first_comment.mli</code> is testing the same thing but
-     at the toplevel. We should see <code>bar</code> inside 
-    <a href="Stop-O.html"><code>O</code></a>.
+    <code>stop_first_comment.mli</code>
+     is testing the same thing but at the toplevel. We should see 
+    <code>bar</code> inside <a href="Stop-O.html"><code>O</code></a>.
    </p>
    <div class="odoc-spec">
     <div class="spec module anchored" id="module-O">

--- a/test/generators/html/Toplevel_comments-Comments_on_open.html
+++ b/test/generators/html/Toplevel_comments-Comments_on_open.html
@@ -36,8 +36,8 @@
      </code>
     </div>
    </div><h3 id="sec"><a href="#sec" class="anchor"></a>Section</h3>
-   <p>Comments attached to open are treated as floating comments. Referencing
-     <a href="#sec" title="sec">Section</a> 
+   <p>Comments attached to open are treated as floating comments. Referencing 
+    <a href="#sec" title="sec">Section</a> 
     <a href="Toplevel_comments-Comments_on_open-M.html#type-t">
      <code>M.t</code>
     </a> works

--- a/test/generators/html/Toplevel_comments-Ref_in_synopsis.html
+++ b/test/generators/html/Toplevel_comments-Ref_in_synopsis.html
@@ -16,8 +16,9 @@
   <header class="odoc-preamble">
    <h1>Module <code><span>Toplevel_comments.Ref_in_synopsis</span></code>
    </h1><p><a href="#type-t"><code>t</code></a>.</p>
-   <p>This reference should resolve in the context of this module, even
-     when used as a synopsis.
+   <p>
+    This reference should resolve in the context of this module, even when
+    used as a synopsis.
    </p>
   </header>
   <div class="odoc-content">

--- a/test/generators/html/Toplevel_comments.html
+++ b/test/generators/html/Toplevel_comments.html
@@ -13,8 +13,9 @@
   </nav>
   <header class="odoc-preamble">
    <h1>Module <code><span>Toplevel_comments</span></code></h1>
-   <p>A doc comment at the beginning of a module is considered to be 
-    that module's doc.
+   <p>
+    A doc comment at the beginning of a module is considered to be that
+    module's doc.
    </p>
   </header>
   <div class="odoc-content">

--- a/test/generators/html/mld.html
+++ b/test/generators/html/mld.html
@@ -13,8 +13,9 @@
   </nav>
   <header class="odoc-preamble">
    <h1 id="mld-page"><a href="#mld-page" class="anchor"></a>Mld Page</h1>
-   <p>This is an <code>.mld</code> file. It doesn't have an auto-generated
-     title, like modules and other pages generated fully by odoc do.
+   <p>This is an <code>.mld</code>
+     file. It doesn't have an auto-generated title, like modules and other
+    pages generated fully by odoc do.
    </p><p>It will have a TOC generated from section headings.</p>
   </header>
   <div class="odoc-tocs">

--- a/test/generators/markdown/Bugs_post_406.md
+++ b/test/generators/markdown/Bugs_post_406.md
@@ -1,7 +1,7 @@
 
 # Module `Bugs_post_406`
 
-Let-open in class types, https://github.com/ocaml/odoc/issues/543 This was added to the language in 4\.06
+Let-open in class types, https://github.com/ocaml/odoc/issues/543 This was added to the language in 4.06
 
 ```ocaml
 class type  let_open = object ... end

--- a/test/generators/markdown/Ocamlary.md
+++ b/test/generators/markdown/Ocamlary.md
@@ -213,7 +213,7 @@ since mesozoic
 ```ocaml
 val changing : unit
 ```
-This value has had changes in 1\.0.0, 1\.1.0, and 1\.2.0.
+This value has had changes in 1.0.0, 1.1.0, and 1.2.0.
 
 before 1\.0.0 before 1.0.0
 before 1\.1.0 before 1.1.0
@@ -370,7 +370,7 @@ type poly_variant = [
 ```
 This comment is for `poly_variant`.
 
-Wow\! It was a polymorphic variant\!
+Wow! It was a polymorphic variant\!
 
 ```ocaml
 type (_, _) full_gadt = 
@@ -381,7 +381,7 @@ type (_, _) full_gadt =
 ```
 This comment is for `full_gadt`.
 
-Wow\! It was a GADT\!
+Wow! It was a GADT\!
 
 ```ocaml
 type 'a partial_gadt = 
@@ -391,7 +391,7 @@ type 'a partial_gadt =
 ```
 This comment is for `partial_gadt`.
 
-Wow\! It was a mixed GADT\!
+Wow! It was a mixed GADT\!
 
 ```ocaml
 type alias = variant

--- a/test/generators/markdown/Section.md
+++ b/test/generators/markdown/Section.md
@@ -34,4 +34,4 @@ val foo : unit
 
 ## *This* `section` **title** has markup
 
-But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents \- no link will be nested inside another link.
+But links are impossible thanks to the parser, so we never have trouble rendering a section title in a table of contents - no link will be nested inside another link.

--- a/test/generators/markdown/Toplevel_comments-Alias.md
+++ b/test/generators/markdown/Toplevel_comments-Alias.md
@@ -3,7 +3,7 @@
 
 Doc of `Alias`.
 
-Doc of `T`, part 2\.
+Doc of `T`, part 2.
 
 ```ocaml
 type t

--- a/test/generators/markdown/Toplevel_comments-Include_inline'.md
+++ b/test/generators/markdown/Toplevel_comments-Include_inline'.md
@@ -1,9 +1,9 @@
 
 # Module `Toplevel_comments.Include_inline'`
 
-Doc of `Include_inline`, part 1\.
+Doc of `Include_inline`, part 1.
 
-Doc of `Include_inline`, part 2\.
+Doc of `Include_inline`, part 2.
 
 part 3
 

--- a/test/generators/markdown/Toplevel_comments-Include_inline.md
+++ b/test/generators/markdown/Toplevel_comments-Include_inline.md
@@ -1,7 +1,7 @@
 
 # Module `Toplevel_comments.Include_inline`
 
-Doc of `T`, part 2\.
+Doc of `T`, part 2.
 
 ```ocaml
 type t

--- a/test/generators/markdown/Toplevel_comments-M''.md
+++ b/test/generators/markdown/Toplevel_comments-M''.md
@@ -1,6 +1,6 @@
 
 # Module `Toplevel_comments.M''`
 
-Doc of `M''`, part 1\.
+Doc of `M''`, part 1.
 
-Doc of `M''`, part 2\.
+Doc of `M''`, part 2.

--- a/test/generators/markdown/Toplevel_comments-class-c1.md
+++ b/test/generators/markdown/Toplevel_comments-class-c1.md
@@ -1,6 +1,6 @@
 
 # Class `Toplevel_comments.c1`
 
-Doc of `c1`, part 1\.
+Doc of `c1`, part 1.
 
-Doc of `c1`, part 2\.
+Doc of `c1`, part 2.

--- a/test/generators/markdown/Toplevel_comments-class-c2.md
+++ b/test/generators/markdown/Toplevel_comments-class-c2.md
@@ -3,4 +3,4 @@
 
 Doc of `c2`.
 
-Doc of `ct`, part 2\.
+Doc of `ct`, part 2.

--- a/test/generators/markdown/Toplevel_comments-class-type-ct.md
+++ b/test/generators/markdown/Toplevel_comments-class-type-ct.md
@@ -1,6 +1,6 @@
 
 # Class type `Toplevel_comments.ct`
 
-Doc of `ct`, part 1\.
+Doc of `ct`, part 1.
 
-Doc of `ct`, part 2\.
+Doc of `ct`, part 2.

--- a/test/generators/markdown/Toplevel_comments-module-type-Include_inline_T'.md
+++ b/test/generators/markdown/Toplevel_comments-module-type-Include_inline_T'.md
@@ -1,9 +1,9 @@
 
 # Module type `Toplevel_comments.Include_inline_T'`
 
-Doc of `Include_inline_T'`, part 1\.
+Doc of `Include_inline_T'`, part 1.
 
-Doc of `Include_inline_T'`, part 2\.
+Doc of `Include_inline_T'`, part 2.
 
 part 3
 

--- a/test/generators/markdown/Toplevel_comments-module-type-Include_inline_T.md
+++ b/test/generators/markdown/Toplevel_comments-module-type-Include_inline_T.md
@@ -1,7 +1,7 @@
 
 # Module type `Toplevel_comments.Include_inline_T`
 
-Doc of `T`, part 2\.
+Doc of `T`, part 2.
 
 ```ocaml
 type t

--- a/test/generators/markdown/Toplevel_comments-module-type-T.md
+++ b/test/generators/markdown/Toplevel_comments-module-type-T.md
@@ -1,9 +1,9 @@
 
 # Module type `Toplevel_comments.T`
 
-Doc of `T`, part 1\.
+Doc of `T`, part 1.
 
-Doc of `T`, part 2\.
+Doc of `T`, part 2.
 
 ```ocaml
 type t

--- a/test/generators/markdown/Toplevel_comments.md
+++ b/test/generators/markdown/Toplevel_comments.md
@@ -6,27 +6,27 @@ A doc comment at the beginning of a module is considered to be that module's doc
 ```ocaml
 module type T = sig ... end
 ```
-Doc of `T`, part 1\.
+Doc of `T`, part 1.
 
 ```ocaml
 module Include_inline : sig ... end
 ```
-Doc of `T`, part 2\.
+Doc of `T`, part 2.
 
 ```ocaml
 module Include_inline' : sig ... end
 ```
-Doc of `Include_inline`, part 1\.
+Doc of `Include_inline`, part 1.
 
 ```ocaml
 module type Include_inline_T = sig ... end
 ```
-Doc of `T`, part 2\.
+Doc of `T`, part 2.
 
 ```ocaml
 module type Include_inline_T' = sig ... end
 ```
-Doc of `Include_inline_T'`, part 1\.
+Doc of `Include_inline_T'`, part 1.
 
 ```ocaml
 module M : sig ... end
@@ -41,7 +41,7 @@ Doc of `M'` from outside
 ```ocaml
 module M'' : sig ... end
 ```
-Doc of `M''`, part 1\.
+Doc of `M''`, part 1.
 
 ```ocaml
 module Alias : T
@@ -51,12 +51,12 @@ Doc of `Alias`.
 ```ocaml
 class c1 : int -> object ... end
 ```
-Doc of `c1`, part 1\.
+Doc of `c1`, part 1.
 
 ```ocaml
 class type  ct = object ... end
 ```
-Doc of `ct`, part 1\.
+Doc of `ct`, part 1.
 
 ```ocaml
 class c2 : ct

--- a/test/generators/markdown/mld.md
+++ b/test/generators/markdown/mld.md
@@ -17,7 +17,7 @@ Another paragraph in section.
 
 This is another section.
 
-Another paragraph in section 2\.
+Another paragraph in section 2.
 
 
 ### Subsection
@@ -33,6 +33,6 @@ Yet another paragraph in subsection.
 
 This is another subsection.
 
-Another paragraph in subsection 2\.
+Another paragraph in subsection 2.
 
-Yet another paragraph in subsection 2\.
+Yet another paragraph in subsection 2.

--- a/test/model/semantics/expected/author.expected
+++ b/test/model/semantics/expected/author.expected
@@ -96,7 +96,7 @@ foo
 --- input ---
 foo @author Bar
 --- output ---
-{"value":[{"`Paragraph":[{"`Word":"foo"},"`Space"]},{"`Tag":{"`Author":"Bar"}}],"warnings":["File \"f.ml\", line 1, characters 4-15:\n'@author' should begin on its own line.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
+{"value":[{"`Paragraph":[{"`Word":"foo "}]},{"`Tag":{"`Author":"Bar"}}],"warnings":["File \"f.ml\", line 1, characters 4-15:\n'@author' should begin on its own line.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
 --- input ---
 [@author Foo]
 --- output ---
@@ -117,24 +117,24 @@ foo @author Bar
 --- input ---
 - foo @author Bar
 --- output ---
-{"value":[{"`List":["`Unordered",[[{"`Paragraph":[{"`Word":"foo"},"`Space"]},{"`Paragraph":[{"`Word":"@author"},"`Space",{"`Word":" Bar"}]}]]]}],"warnings":["File \"f.ml\", line 1, characters 6-17:\n'@author' is not allowed in '-' (bulleted list item).\nSuggestion: move '@author' outside of any other markup.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
+{"value":[{"`List":["`Unordered",[[{"`Paragraph":[{"`Word":"foo "}]},{"`Paragraph":[{"`Word":"@author  Bar"}]}]]]}],"warnings":["File \"f.ml\", line 1, characters 6-17:\n'@author' is not allowed in '-' (bulleted list item).\nSuggestion: move '@author' outside of any other markup.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
 --- input ---
 - @author Foo
 --- output ---
-{"value":[{"`List":["`Unordered",[[{"`Paragraph":[{"`Word":"@author"},"`Space",{"`Word":" Foo"}]}]]]}],"warnings":["File \"f.ml\", line 1, characters 2-13:\n'@author' is not allowed in '-' (bulleted list item).\nSuggestion: move '@author' outside of any other markup.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
+{"value":[{"`List":["`Unordered",[[{"`Paragraph":[{"`Word":"@author  Foo"}]}]]]}],"warnings":["File \"f.ml\", line 1, characters 2-13:\n'@author' is not allowed in '-' (bulleted list item).\nSuggestion: move '@author' outside of any other markup.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
 --- input ---
 {ul {li foo @author Bar}}
 --- output ---
-{"value":[{"`List":["`Unordered",[[{"`Paragraph":[{"`Word":"foo"},"`Space"]},{"`Paragraph":[{"`Word":"@author"},"`Space",{"`Word":" Bar}}"}]}]]]}],"warnings":["File \"f.ml\", line 1, characters 12-25:\n'@author' is not allowed in '{li ...}' (list item).\nSuggestion: move '@author' outside of any other markup.","File \"f.ml\", line 1, characters 25-25:\nEnd of text is not allowed in '{li ...}' (list item).\nSuggestion: add '}'.","File \"f.ml\", line 1, characters 25-25:\nEnd of text is not allowed in '{ul ...}' (bulleted list).\nSuggestion: add '}'.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
+{"value":[{"`List":["`Unordered",[[{"`Paragraph":[{"`Word":"foo "}]},{"`Paragraph":[{"`Word":"@author  Bar}}"}]}]]]}],"warnings":["File \"f.ml\", line 1, characters 12-25:\n'@author' is not allowed in '{li ...}' (list item).\nSuggestion: move '@author' outside of any other markup.","File \"f.ml\", line 1, characters 25-25:\nEnd of text is not allowed in '{li ...}' (list item).\nSuggestion: add '}'.","File \"f.ml\", line 1, characters 25-25:\nEnd of text is not allowed in '{ul ...}' (bulleted list).\nSuggestion: add '}'.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
 --- input ---
 {ul {li @author Foo}}
 --- output ---
-{"value":[{"`List":["`Unordered",[[{"`Paragraph":[{"`Word":"@author"},"`Space",{"`Word":" Foo}}"}]}]]]}],"warnings":["File \"f.ml\", line 1, characters 8-21:\n'@author' is not allowed in '{li ...}' (list item).\nSuggestion: move '@author' outside of any other markup.","File \"f.ml\", line 1, characters 21-21:\nEnd of text is not allowed in '{li ...}' (list item).\nSuggestion: add '}'.","File \"f.ml\", line 1, characters 21-21:\nEnd of text is not allowed in '{ul ...}' (bulleted list).\nSuggestion: add '}'.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
+{"value":[{"`List":["`Unordered",[[{"`Paragraph":[{"`Word":"@author  Foo}}"}]}]]]}],"warnings":["File \"f.ml\", line 1, characters 8-21:\n'@author' is not allowed in '{li ...}' (list item).\nSuggestion: move '@author' outside of any other markup.","File \"f.ml\", line 1, characters 21-21:\nEnd of text is not allowed in '{li ...}' (list item).\nSuggestion: add '}'.","File \"f.ml\", line 1, characters 21-21:\nEnd of text is not allowed in '{ul ...}' (bulleted list).\nSuggestion: add '}'.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
 --- input ---
 {ul {li foo
 @author Bar}}
 --- output ---
-{"value":[{"`List":["`Unordered",[[{"`Paragraph":[{"`Word":"foo"}]},{"`Paragraph":[{"`Word":"@author"},"`Space",{"`Word":" Bar}}"}]}]]]}],"warnings":["File \"f.ml\", line 2, characters 0-13:\n'@author' is not allowed in '{li ...}' (list item).\nSuggestion: move '@author' outside of any other markup.","File \"f.ml\", line 2, characters 13-13:\nEnd of text is not allowed in '{li ...}' (list item).\nSuggestion: add '}'.","File \"f.ml\", line 2, characters 13-13:\nEnd of text is not allowed in '{ul ...}' (bulleted list).\nSuggestion: add '}'.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
+{"value":[{"`List":["`Unordered",[[{"`Paragraph":[{"`Word":"foo"}]},{"`Paragraph":[{"`Word":"@author  Bar}}"}]}]]]}],"warnings":["File \"f.ml\", line 2, characters 0-13:\n'@author' is not allowed in '{li ...}' (list item).\nSuggestion: move '@author' outside of any other markup.","File \"f.ml\", line 2, characters 13-13:\nEnd of text is not allowed in '{li ...}' (list item).\nSuggestion: add '}'.","File \"f.ml\", line 2, characters 13-13:\nEnd of text is not allowed in '{ul ...}' (bulleted list).\nSuggestion: add '}'.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
 --- input ---
 {ul @author Foo}
 --- output ---

--- a/test/model/semantics/expected/heading.expected
+++ b/test/model/semantics/expected/heading.expected
@@ -58,7 +58,7 @@ Foo}
 
 }
 --- output ---
-{"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"foo-"]},[{"`Word":"Foo"},"`Space"]]}],"warnings":["File \"f.ml\", line 2, characters 0-0:\nBlank line is not allowed in '{2 ...}' (section heading)."]}
+{"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"foo-"]},[{"`Word":"Foo\n\n"}]]}],"warnings":["File \"f.ml\", line 2, characters 0-0:\nBlank line is not allowed in '{2 ...}' (section heading)."]}
 --- input ---
 {2 [foo]}
 --- output ---
@@ -80,11 +80,11 @@ baz]}
 --- input ---
 {2 {e foo bar}}
 --- output ---
-{"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"foo-bar"]},[{"`Styled":["`Emphasis",[{"`Word":"foo"},"`Space",{"`Word":"bar"}]]}]]}],"warnings":[]}
+{"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"foo-bar"]},[{"`Styled":["`Emphasis",[{"`Word":"foo bar"}]]}]]}],"warnings":[]}
 --- input ---
 {2 foo bar}
 --- output ---
-{"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"foo-bar"]},[{"`Word":"foo"},"`Space",{"`Word":"bar"}]]}],"warnings":[]}
+{"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"foo-bar"]},[{"`Word":"foo bar"}]]}],"warnings":[]}
 --- input ---
 {2 {2 Foo}}
 --- output ---
@@ -100,7 +100,7 @@ baz]}
 --- input ---
 foo {2 Bar}
 --- output ---
-{"value":[{"`Paragraph":[{"`Word":"foo"},"`Space"]},{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"bar"]},[{"`Word":"Bar"}]]}],"warnings":["File \"f.ml\", line 1, characters 4-6:\n'{2 ...}' (section heading) should begin on its own line.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
+{"value":[{"`Paragraph":[{"`Word":"foo "}]},{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"bar"]},[{"`Word":"Bar"}]]}],"warnings":["File \"f.ml\", line 1, characters 4-6:\n'{2 ...}' (section heading) should begin on its own line.","File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
 --- input ---
 {2 Foo}
 bar
@@ -118,11 +118,11 @@ foo
 --- input ---
 {2 :foo Bar}
 --- output ---
-{"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},":foo-bar"]},[{"`Word":":foo"},"`Space",{"`Word":"Bar"}]]}],"warnings":[]}
+{"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},":foo-bar"]},[{"`Word":":foo Bar"}]]}],"warnings":[]}
 --- input ---
 {2: foo Bar}
 --- output ---
-{"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"foo-bar"]},[{"`Word":"foo"},"`Space",{"`Word":"Bar"}]]}],"warnings":["File \"f.ml\", line 1, characters 0-3:\nHeading label should not be empty."]}
+{"value":[{"`Heading":[{"heading_level":"`Subsection","heading_label_explicit":"false"},{"`Label":[{"`Page":["None","f.ml"]},"foo-bar"]},[{"`Word":"foo Bar"}]]}],"warnings":["File \"f.ml\", line 1, characters 0-3:\nHeading label should not be empty."]}
 --- input ---
 {2:foo}
 --- output ---

--- a/test/model/semantics/expected/simple_reference.expected
+++ b/test/model/semantics/expected/simple_reference.expected
@@ -17,7 +17,7 @@ bar{!foo}
 --- input ---
 bar {!foo}
 --- output ---
-{"value":[{"`Paragraph":[{"`Word":"bar"},"`Space",{"`Reference":[{"`Root":["foo","`TUnknown"]},[]]}]}],"warnings":["File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
+{"value":[{"`Paragraph":[{"`Word":"bar "},{"`Reference":[{"`Root":["foo","`TUnknown"]},[]]}]}],"warnings":["File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
 --- input ---
 {!foo}bar
 --- output ---
@@ -25,7 +25,7 @@ bar {!foo}
 --- input ---
 {!foo} bar
 --- output ---
-{"value":[{"`Paragraph":[{"`Reference":[{"`Root":["foo","`TUnknown"]},[]]},"`Space",{"`Word":"bar"}]}],"warnings":["File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
+{"value":[{"`Paragraph":[{"`Reference":[{"`Root":["foo","`TUnknown"]},[]]},{"`Word":" bar"}]}],"warnings":["File \"f.ml.mld\":\nPages (.mld files) should start with a heading."]}
 --- input ---
 {!val:foo}
 --- output ---

--- a/test/xref2/canonical_hidden_module.t/run.t
+++ b/test/xref2/canonical_hidden_module.t/run.t
@@ -157,8 +157,9 @@ See the comments on the types at the end of test.mli for the expectation.
        </code>
       </div>
       <div class="spec-doc">
-       <p>This should render as A.t but link to A_nonhidden/index.html 
-        - since A has no expansion
+       <p>
+        This should render as A.t but link to A_nonhidden/index.html - since A
+        has no expansion
        </p>
       </div>
      </div>
@@ -168,8 +169,9 @@ See the comments on the types at the end of test.mli for the expectation.
        <code><span><span class="keyword">type</span> b</span></code>
       </div>
       <div class="spec-doc">
-       <p>This should have no RHS as it's hidden and there is no canonical
-         alternative
+       <p>
+        This should have no RHS as it's hidden and there is no canonical
+        alternative
        </p>
       </div>
      </div>

--- a/test/xref2/github_issue_342.t/run.t
+++ b/test/xref2/github_issue_342.t/run.t
@@ -31,7 +31,7 @@ The rendered headings
       <a href="A/index.html" title="A">with text</a> in title
   --
      <h2 id="an-url--and-with-text-in-a-title">
-      <a href="#an-url--and-with-text-in-a-title" class="anchor"></a>An
-       url <a href="http://ocaml.org">http://ocaml.org</a> and 
+      <a href="#an-url--and-with-text-in-a-title" class="anchor"></a>An url 
+      <a href="http://ocaml.org">http://ocaml.org</a> and 
       <a href="http://ocaml.org">with text</a> in a title
 

--- a/test/xref2/labels/ambiguous_label.t/run.t
+++ b/test/xref2/labels/ambiguous_label.t/run.t
@@ -44,10 +44,10 @@ References should resolve to the first occurence of the ambiguous label. It is
 not possible to use the internal label name in references:
 
   $ odoc_print test.odocl | jq -c '.. | .["`Reference"]? | select(.)'
-  [{"`Resolved":{"`Identifier":{"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"example"]}}},[{"`Word":"Should"},"`Space",{"`Word":"resolve"},"`Space",{"`Word":"to"},"`Space",{"`Word":"the"},"`Space",{"`Word":"first"},"`Space",{"`Word":"label"}]]
-  [{"`Root":["example_2","`TUnknown"]},[{"`Word":"Shouldn't"},"`Space",{"`Word":"resolve"}]]
+  [{"`Resolved":{"`Identifier":{"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"example"]}}},[{"`Word":"Should resolve to the first label"}]]
+  [{"`Root":["example_2","`TUnknown"]},[{"`Word":"Shouldn't resolve"}]]
 
 A second module has a reference to the ambiguous label:
 
   $ odoc_print test_2.odocl | jq -c '.. | .["`Reference"]? | select(.)'
-  [{"`Resolved":{"`Label":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]}},"example"]}},[{"`Word":"Should"},"`Space",{"`Word":"resolve"},"`Space",{"`Word":"to"},"`Space",{"`Word":"the"},"`Space",{"`Word":"first"},"`Space",{"`Word":"label"}]]
+  [{"`Resolved":{"`Label":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]}},"example"]}},[{"`Word":"Should resolve to the first label"}]]

--- a/test/xref2/labels/labels.t/run.t
+++ b/test/xref2/labels/labels.t/run.t
@@ -27,14 +27,14 @@ References to the labels:
 We expect resolved references and the heading text filled in.
 
   $ odoc_print test.odocl | jq -c '.. | .["`Reference"]? | select(.)'
-  [{"`Resolved":{"`Identifier":{"`Label":[{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"N"]},"B"]}}},[{"`Word":"An"},"`Space",{"`Word":"other"},"`Space",{"`Word":"conflicting"},"`Space",{"`Word":"label"}]]
-  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"B"]}},[{"`Word":"Potentially"},"`Space",{"`Word":"conflicting"},"`Space",{"`Word":"label"}]]
-  [{"`Resolved":{"`Identifier":{"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"A"]}}},[{"`Word":"First"},"`Space",{"`Word":"label"}]]
-  [{"`Resolved":{"`Identifier":{"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"B"]}}},[{"`Word":"Dupplicate"},"`Space",{"`Word":"B"}]]
-  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"C"]}},[{"`Word":"First"},"`Space",{"`Word":"label"},"`Space",{"`Word":"of"},"`Space",{"`Word":"M"}]]
-  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"D"]}},[{"`Word":"Floating"},"`Space",{"`Word":"label"},"`Space",{"`Word":"in"},"`Space",{"`Word":"M"}]]
-  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"B"]}},[{"`Word":"Potentially"},"`Space",{"`Word":"conflicting"},"`Space",{"`Word":"label"}]]
-  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"N"]}},"B"]}},[{"`Word":"An"},"`Space",{"`Word":"other"},"`Space",{"`Word":"conflicting"},"`Space",{"`Word":"label"}]]
+  [{"`Resolved":{"`Identifier":{"`Label":[{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"N"]},"B"]}}},[{"`Word":"An other conflicting label"}]]
+  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"B"]}},[{"`Word":"Potentially conflicting label"}]]
+  [{"`Resolved":{"`Identifier":{"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"A"]}}},[{"`Word":"First label"}]]
+  [{"`Resolved":{"`Identifier":{"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"B"]}}},[{"`Word":"Dupplicate B"}]]
+  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"C"]}},[{"`Word":"First label of M"}]]
+  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"D"]}},[{"`Word":"Floating label in M"}]]
+  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"M"]}},"B"]}},[{"`Word":"Potentially conflicting label"}]]
+  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"N"]}},"B"]}},[{"`Word":"An other conflicting label"}]]
 
   $ odoc html-generate --indent -o html test.odocl
 

--- a/test/xref2/labels/shadowed_in_submodules.t/run.t
+++ b/test/xref2/labels/shadowed_in_submodules.t/run.t
@@ -7,6 +7,6 @@ There should be no ambiguous labels in this example.
 All the references should resolve and point to what's written in the text.
 
   $ odoc_print test.odocl | jq -c '.. | .["`Reference"]? | select(.)'
-  [{"`Resolved":{"`Identifier":{"`Label":[{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"X"]},"foo"]}}},[{"`Word":"Expecting"},"`Space",{"`Word":"H2"}]]
-  [{"`Resolved":{"`Identifier":{"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"foo"]}}},[{"`Word":"Expecting"},"`Space",{"`Word":"H1"}]]
-  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"X"]}},"foo"]}},[{"`Word":"Expecting"},"`Space",{"`Word":"H2"}]]
+  [{"`Resolved":{"`Identifier":{"`Label":[{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"X"]},"foo"]}}},[{"`Word":"Expecting H2"}]]
+  [{"`Resolved":{"`Identifier":{"`Label":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"foo"]}}},[{"`Word":"Expecting H1"}]]
+  [{"`Resolved":{"`Label":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Test"]},"X"]}},"foo"]}},[{"`Word":"Expecting H2"}]]

--- a/test/xref2/module_list.t/run.t
+++ b/test/xref2/module_list.t/run.t
@@ -16,37 +16,37 @@ Everything should resolve:
 
   $ odoc_print main.odocl | jq -c '.. | .["`Modules"]? | select(.) | .[] | .[]'
   {"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"External"]}}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"External"},{"`Word":"."}]}
+  {"Some":[{"`Word":"Doc for "},{"`Code_span":"External"},{"`Word":"."}]}
   {"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"External"]}},"X"]}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"X"},{"`Word":"."}]}
+  {"Some":[{"`Word":"Doc for "},{"`Code_span":"X"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}}}
   "None"
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Internal"]}}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"Internal"},{"`Word":"."}]}
+  {"Some":[{"`Word":"Doc for "},{"`Code_span":"Internal"},{"`Word":"."}]}
   {"`Resolved":{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Internal"]}},"Y"]}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Word":"Internal."},{"`Code_span":"X"},{"`Word":"."},"`Space",{"`Word":"An"},"`Space",{"`Word":"other"},"`Space",{"`Word":"sentence."}]}
+  {"Some":[{"`Word":"Doc for Internal."},{"`Code_span":"X"},{"`Word":". An other sentence."}]}
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Z"]}}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"Z"},{"`Word":"."}]}
+  {"Some":[{"`Word":"Doc for "},{"`Code_span":"Z"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"F"]}}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"F ()"},{"`Word":"."}]}
+  {"Some":[{"`Word":"Doc for "},{"`Code_span":"F ()"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Type_of"]}}}
   "None"
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Type_of_str"]}}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"of"},"`Space",{"`Code_span":"Type_of_str"},{"`Word":"."}]}
+  {"Some":[{"`Word":"Doc of "},{"`Code_span":"Type_of_str"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"With_type"]}}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"T"},{"`Word":"."}]}
+  {"Some":[{"`Word":"Doc for "},{"`Code_span":"T"},{"`Word":"."}]}
   {"`Resolved":{"`Alias":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"External"]}},"X"]},{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Alias"]}}]}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"X"},{"`Word":"."}]}
+  {"Some":[{"`Word":"Doc for "},{"`Code_span":"X"},{"`Word":"."}]}
   {"`Resolved":{"`Alias":[{"`Canonical":[{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Internal"]}},"C1"]},{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"C1"]}}}]},{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"C1"]}}]}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"C1"},{"`Word":"."}]}
+  {"Some":[{"`Word":"Doc for "},{"`Code_span":"C1"},{"`Word":"."}]}
   {"`Resolved":{"`Alias":[{"`Canonical":[{"`Module":[{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Internal"]}},"C2"]},{"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"C2"]}}}]},{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"C2"]}}]}}
   "None"
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Inline_include"]}}}
-  {"Some":[{"`Word":"Doc"},"`Space",{"`Word":"for"},"`Space",{"`Code_span":"T"},{"`Word":"."}]}
+  {"Some":[{"`Word":"Doc for "},{"`Code_span":"T"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Starts_with_open"]}}}
-  {"Some":[{"`Word":"Synopsis"},"`Space",{"`Word":"of"},"`Space",{"`Code_span":"Starts_with_open"},{"`Word":"."}]}
+  {"Some":[{"`Word":"Synopsis of "},{"`Code_span":"Starts_with_open"},{"`Word":"."}]}
   {"`Resolved":{"`Identifier":{"`Module":[{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]},"Resolve_synopsis"]}}}
-  {"Some":[{"`Word":"This"},"`Space",{"`Word":"should"},"`Space",{"`Word":"be"},"`Space",{"`Word":"resolved"},"`Space",{"`Word":"when"},"`Space",{"`Word":"included:"},"`Space",{"`Reference":[{"`Resolved":{"`Type":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]},"t"]}},[]]},{"`Word":"."},"`Space",{"`Word":"These"},"`Space",{"`Word":"shouldn't:"},"`Space",{"`Reference":[{"`Root":["t","`TUnknown"]},[]]},"`Space",{"`Reference":[{"`Dot":[{"`Root":["Resolve_synopsis","`TUnknown"]},"t"]},[]]}]}
+  {"Some":[{"`Word":"This should be resolved when included: "},{"`Reference":[{"`Resolved":{"`Type":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]},"t"]}},[]]},{"`Word":". These\n      shouldn't: "},{"`Reference":[{"`Root":["t","`TUnknown"]},[]]},{"`Space":" "},{"`Reference":[{"`Dot":[{"`Root":["Resolve_synopsis","`TUnknown"]},"t"]},[]]}]}
   {"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"External"]}},"Resolve_synopsis"]}}
   {"Some":[{"`Reference":[{"`Root":["t","`TUnknown"]},[]]}]}
 
@@ -55,6 +55,6 @@ References in the synopses above should be resolved.
 
   $ odoc_print external.odocl | jq -c '.. | .["`Modules"]? | select(.) | .[] | .[]'
   {"`Resolved":{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]}}
-  {"Some":[{"`Word":"This"},"`Space",{"`Word":"should"},"`Space",{"`Word":"be"},"`Space",{"`Word":"resolved"},"`Space",{"`Word":"when"},"`Space",{"`Word":"included:"},"`Space",{"`Reference":[{"`Resolved":{"`Type":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]},"t"]}},[]]},{"`Word":"."},"`Space",{"`Word":"These"},"`Space",{"`Word":"shouldn't:"},"`Space",{"`Reference":[{"`Root":["t","`TUnknown"]},[]]},"`Space",{"`Reference":[{"`Dot":[{"`Root":["Resolve_synopsis","`TUnknown"]},"t"]},[]]}]}
+  {"Some":[{"`Word":"This should be resolved when included: "},{"`Reference":[{"`Resolved":{"`Type":[{"`Module":[{"`Identifier":{"`Root":[{"Some":{"`Page":["None","test"]}},"Main"]}},"Resolve_synopsis"]},"t"]}},[]]},{"`Word":". These\n      shouldn't: "},{"`Reference":[{"`Root":["t","`TUnknown"]},[]]},{"`Space":" "},{"`Reference":[{"`Dot":[{"`Root":["Resolve_synopsis","`TUnknown"]},"t"]},[]]}]}
 
 'Type_of' and 'Alias' don't have a summary. `C1` and `C2` neither, we expect at least `C2` to have one.

--- a/test/xref2/module_preamble.t/run.t
+++ b/test/xref2/module_preamble.t/run.t
@@ -95,8 +95,9 @@ and that "hidden" modules (eg. `A__b`, rendered to `html/A__b`) are not rendered
     <div class="odoc-content">
      <h3 id="an-heading"><a href="#an-heading" class="anchor"></a>An heading
      </h3>
-     <p>This paragraph is not part of the preamble. It'll be rendered in
-       the &quot;content&quot;.
+     <p>
+      This paragraph is not part of the preamble. It'll be rendered in the
+      &quot;content&quot;.
      </p>
      <div class="odoc-spec">
       <div class="spec type anchored" id="type-t">

--- a/test/xref2/module_type_alias.t/run.t
+++ b/test/xref2/module_type_alias.t/run.t
@@ -64,7 +64,9 @@ as they are both referencing items that won't be expanded.
                   []
                 ]
               },
-              "`Space",
+              {
+                "`Space": " "
+              },
               {
                 "`Reference": [
                   {

--- a/test/xref2/path_references.t/run.t
+++ b/test/xref2/path_references.t/run.t
@@ -33,27 +33,27 @@ Helper that extracts references in a compact way. Headings help to interpret the
   $ jq_references() { jq -c '.. | objects | if has("`Reference") then . elif has("`Heading") then [ .. | .["`Word"]? | select(.) ] else empty end'; }
 
   $ odoc_print ./h/pkg/page-foo.odocl | jq_references
-  ["Title","for","foo"]
-  ["Page","foo"]
+  ["Title for foo"]
+  ["Page foo"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
-  ["Page","subdir/bar"]
+  ["Page subdir/bar"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Root":["bar","`TUnknown"]},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
-  ["Page","dup"]
+  ["Page dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"dup"]}}},[]]}
-  ["Page","subdir/dup"]
+  ["Page subdir/dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"dup"]}}},[]]}
-  ["Module","Test"]
+  ["Module Test"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["Test"]]},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"libname"]}},"Test"]}}},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
@@ -64,48 +64,48 @@ Helper that extracts references in a compact way. Headings help to interpret the
   {"`Reference":[{"`Resolved":{"`Identifier":{"`AssetFile":[{"`Page":["None","pkg"]},"img.png"]}}},[]]}
 
   $ odoc_print ./h/pkg/subdir/page-bar.odocl | jq_references
-  ["Title","for","subdir/bar"]
-  ["Page","foo"]
+  ["Title for subdir/bar"]
+  ["Page foo"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
-  ["Page","subdir/bar"]
+  ["Page subdir/bar"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
-  ["Page","dup"]
+  ["Page dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"dup"]}}},[]]}
-  ["Page","subdir/dup"]
+  ["Page subdir/dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"dup"]}}},[]]}
-  ["Module","Test"]
+  ["Module Test"]
   {"`Reference":[{"`Any_path":["`TCurrentPackage",["libname","Test"]]},[]]}
   {"`Reference":[{"`Any_path":["`TAbsolutePath",["pkg","libname","Test"]]},[]]}
   {"`Reference":[{"`Any_path":["`TRelativePath",["Test"]]},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"libname"]}},"Test"]}}},[]]}
 
   $ odoc_print ./h/pkg/libname/test.odocl | jq_references
-  ["Page","foo"]
+  ["Page foo"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"foo"]}}},[]]}
-  ["Page","subdir/bar"]
+  ["Page subdir/bar"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"bar"]}}},[]]}
   {"`Reference":[{"`Root":["bar","`TUnknown"]},[]]}
-  ["Page","dup"]
+  ["Page dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":["None","pkg"]}},"dup"]}}},[]]}
-  ["Page","subdir/dup"]
+  ["Page subdir/dup"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"dup"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`LeafPage":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"subdir"]}},"dup"]}}},[]]}
-  ["Module","Test"]
+  ["Module Test"]
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"libname"]}},"Test"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"libname"]}},"Test"]}}},[]]}
   {"`Reference":[{"`Resolved":{"`Identifier":{"`Root":[{"Some":{"`Page":[{"Some":{"`Page":["None","pkg"]}},"libname"]}},"Test"]}}},[]]}


### PR DESCRIPTION
Rather than storing comments as `` [`Word "rather"; `Space; `Word "than"; `Space; `Word "storing";...] `` each of which actually also carries a location, store them as just one: `` [`Word "rather than storing ..."] `` 

This is built on top of #1480 so we can be sure it doesn't clobber the memoizing.